### PR TITLE
Evaluation pipeline for French benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,10 @@
 __pycache__/
 *.py[codz]
 *$py.class
+
+# Extra
 uv.lock
+results_french_evals/
 
 # C extensions
 *.so

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ __pycache__/
 
 # Extra
 uv.lock
-results_french_evals/
+results_evals/
 
 # C extensions
 *.so

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 # Extra
 uv.lock
 results_evals/
+test.py
 
 # C extensions
 *.so

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PYTHON               := uv run python
 
 EVAL_SCRIPT		:= src/eval/eval.py
 
-EVAL_TASKS ?= ifeval_fr
+EVAL_TASKS ?= ifeval-fr
 EVAL_MODEL ?= Qwen/Qwen3-0.6B
 
 .PHONY: env eval

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@ PYTHON               := uv run python
 
 EVAL_SCRIPT		:= src/eval/eval.py
 
-EVAL_TASKS ?= ifeval-fr
-EVAL_MODEL ?= Qwen/Qwen3-0.6B
+EVAL_TASKS ?= gpqa-diamond-fr
+EVAL_MODEL ?= Qwen/Qwen2.5-1.5B-Instruct
 
 .PHONY: env eval
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,12 @@
-PYTHON_VERSION       := 3.12
+PYTHON_VERSION       := 3.10
 PYTHON               := uv run python
 
-.PHONY: env
+EVAL_SCRIPT		:= src/eval/eval.py
+
+EVAL_TASKS ?= ifeval_fr
+EVAL_MODEL ?= Qwen/Qwen3-0.6B
+
+.PHONY: env eval
 
 env:
 	@command -v uv >/dev/null 2>&1 || { \
@@ -12,3 +17,7 @@ env:
 	@uv sync --python $(PYTHON_VERSION)
 	@echo "Environment ready."
 
+eval:
+	$(PYTHON) $(EVAL_SCRIPT) \
+		--tasks $(EVAL_TASKS) \
+		--model $(EVAL_MODEL) \

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PYTHON               := uv run python
 
 EVAL_SCRIPT		:= src/eval/eval.py
 
-EVAL_TASKS ?= gpqa-diamond-fr
+EVAL_TASKS ?= ifeval-fr
 EVAL_MODEL ?= Qwen/Qwen2.5-1.5B-Instruct
 
 .PHONY: env eval

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PYTHON               := uv run python
 EVAL_SCRIPT		:= src/eval/eval.py
 
 EVAL_TASKS ?= ifeval-fr
-EVAL_MODEL ?= Qwen/Qwen2.5-1.5B-Instruct
+EVAL_MODEL ?= Qwen/Qwen2.5-0.5B-Instruct
 
 .PHONY: env eval
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ source $HOME/.local/bin/env
 
 ## 2. Evaluation
 
-Currently supports: `IFEval-fr`, `GPQA-fr`, `BBH-fr`, `Math-HARD-fr`
+Currently supports: `IFEval-fr`, `GPQA-fr`, `BBH-fr`, `Math-HARD-fr`, `BoolQ-fr`
 
 ```bash
 # Linux/MacOS

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $env:HF_TOKEN="your_hf_token"
 
 | Task        | Make Command       | Equivalent CLI Command                                                                                                                                               | Default Values                                                                 |
 |-------------|--------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------|
-| Evaluation French Benchmarks   | `make eval`       | `python run_eval.py --tasks EVAL_TASKS --model EVAL_MODEL`                                                                                 | `EVAL_TASKS=ifeval_fr`, `EVAL_MODEL=Qwen/Qwen3-0.6B`                              |
+| Evaluation French Benchmarks   | `make eval`       | `python run_eval.py --tasks EVAL_TASKS --model EVAL_MODEL`                                                                                 | `EVAL_TASKS=ifeval_fr`, `EVAL_MODEL=Qwen/Qwen2.5-1.5B-Instruct`                              |
 
 ⚠️ We use [Lighteval](https://github.com/huggingface/lighteval) and [vLLM](https://github.com/vllm-project/vllm) for evaluation.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ source $HOME/.local/bin/env
 
 ## 2. Evaluation
 
-Currently supports: `IFEval-fr`, `GPQA-fr`, `BBH-fr`
+Currently supports: `IFEval-fr`, `GPQA-fr`, `BBH-fr`, `Math-HARD-fr`
 
 ```bash
 # Linux/MacOS

--- a/README.md
+++ b/README.md
@@ -42,12 +42,12 @@ Parameters: `Temperature=0.0`
 | Evaluation               | Qwen2.5-1.5B | 
 |--------------------------|--------------|
 | IFEval-fr (strict prompt)| 23.78        |
-| GPQA-Diamond-fr          | 27.44        |
+| GPQA-Diamond-fr          | 29.02        |
 | BoolQ-fr                 | 69.3         | 
 | Math-Hard-fr             | 4.77         | 
 | MMLU-fr                  | 48.17        | 
-| BBH-fr                   | -            | 
-| MuSR-fr                  |              | 
+| BBH-fr                   | 49.64        | 
+| MuSR-fr                  | 37.47        | 
 
 
 ## 3. Resources:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Building a French Small Language Model
 
-## Quick Setup
+## 1. Quick Setup
 
 _Using [`uv`](https://github.com/astral-sh/uv) for fast and reliable dependency management._
 
@@ -17,3 +17,28 @@ That's it, you can now run any command you want!
 curl -LsSf https://astral.sh/uv/install.sh | sh
 source $HOME/.local/bin/env
 ```
+
+## 2. Evaluation
+
+```bash
+# Linux/MacOS
+export HF_TOKEN=your_hf_token
+# Windows
+$env:HF_TOKEN="your_hf_token"
+```
+
+| Task        | Make Command       | Equivalent CLI Command                                                                                                                                               | Default Values                                                                 |
+|-------------|--------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------|
+| Evaluation French Benchmarks   | `make eval`       | `python run_eval.py --tasks EVAL_TASKS --model EVAL_MODEL`                                                                                 | `EVAL_TASKS=ifeval_fr`, `EVAL_MODEL=Qwen/Qwen3-0.6B`                              |
+
+⚠️ We use [lighteval](https://github.com/huggingface/lighteval) for evaluation, which may not be fully supported on Windows.
+
+## 3. Results
+
+| Model Name | IFEval-fr (strict prompt) |
+|------------|-------------|
+| Qwen3-0.6B   | 34.7        |
+
+## 3. Resources:
+- [French LLM Leaderboard](https://huggingface.co/spaces/fr-gouv-coordination-ia/llm_leaderboard_fr#/)
+- [OpenLLMFrenchLeadboard Dataset (not official datasets)](https://huggingface.co/collections/le-leadboard/openllmfrenchleadboard-jeu-de-donnees-67126437539a23c65554fd88)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ source $HOME/.local/bin/env
 
 ## 2. Evaluation
 
-Currently supports: `IFEval-fr`, `GPQA-fr`, `BBH-fr`, `Math-HARD-fr`, `BoolQ-fr`, `MMLU-fr`, `MuSR-fr`
+Currently supports: `IFEval-fr`, `GPQA-Diamond-fr`, `BBH-fr`, `Math-HARD-fr`, `BoolQ-fr`, `MMLU-fr`, `MuSR-fr`
 
 ```bash
 # Linux/MacOS
@@ -37,11 +37,17 @@ $env:HF_TOKEN="your_hf_token"
 
 ## 3. Results
 
-| Evaluation               | Qwen3-0.6B | Qwen3-0.6B-Base |
-|--------------------------|------------|-----------------|
-| IFEval-fr (strict prompt)| 20.53      | -               |
-| BBH-fr                   | 34.13      | 40.85           |
-| BoolQ-fr                 | 1.91       | -               |
+Parameters: `Temperature=0.0`
+
+| Evaluation               | Qwen2.5-1.5B | 
+|--------------------------|--------------|
+| IFEval-fr (strict prompt)| 23.78        |
+| GPQA-Diamond-fr          | 27.44        |
+| BoolQ-fr                 | 69.3         | 
+| Math-Hard-fr             | 4.77         | 
+| MMLU-fr                  | 48.17        | 
+| BBH-fr                   | -            | 
+| MuSR-fr                  |              | 
 
 
 ## 3. Resources:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # French Small Language Model
 
-Building a French Small Language Model
+Building a good French Small Language Model.
 
 ## 1. Quick Setup
 
@@ -20,7 +20,7 @@ source $HOME/.local/bin/env
 
 ## 2. Evaluation
 
-Currently supports: `IFEval-fr`, `GPQA-fr`, `BBH-fr`, `Math-HARD-fr`, `BoolQ-fr`
+Currently supports: `IFEval-fr`, `GPQA-fr`, `BBH-fr`, `Math-HARD-fr`, `BoolQ-fr`, `MMLU-fr`, `MuSR-fr`
 
 ```bash
 # Linux/MacOS
@@ -41,6 +41,7 @@ $env:HF_TOKEN="your_hf_token"
 |--------------------------|------------|-----------------|
 | IFEval-fr (strict prompt)| 20.53      | -               |
 | BBH-fr                   | 34.13      | 40.85           |
+| BoolQ-fr                 | 1.91       | -               |
 
 
 ## 3. Resources:

--- a/README.md
+++ b/README.md
@@ -37,9 +37,11 @@ $env:HF_TOKEN="your_hf_token"
 
 ## 3. Results
 
-| Model Name | IFEval-fr (strict prompt) |
-|------------|-------------|
-| Qwen3-0.6B   | 36.2        |
+| Model Name | IFEval-fr (strict prompt) | BBH-fr |
+|------------|-------------|-------------|
+| Qwen3-0.6B   | 20.53        |  34.13         |
+| Qwen3-0.6B-Base   |      -      |    40.85            |
+
 
 ## 3. Resources:
 - [French LLM Leaderboard](https://huggingface.co/spaces/fr-gouv-coordination-ia/llm_leaderboard_fr#/)

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ source $HOME/.local/bin/env
 
 ## 2. Evaluation
 
+Currently supports: `IFEval-fr`, `GPQA-fr`, `BBH-fr`
+
 ```bash
 # Linux/MacOS
 export HF_TOKEN=your_hf_token
@@ -37,7 +39,7 @@ $env:HF_TOKEN="your_hf_token"
 
 | Model Name | IFEval-fr (strict prompt) |
 |------------|-------------|
-| Qwen3-0.6B   | 34.7        |
+| Qwen3-0.6B   | 36.2        |
 
 ## 3. Resources:
 - [French LLM Leaderboard](https://huggingface.co/spaces/fr-gouv-coordination-ia/llm_leaderboard_fr#/)

--- a/README.md
+++ b/README.md
@@ -33,14 +33,14 @@ $env:HF_TOKEN="your_hf_token"
 |-------------|--------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------|
 | Evaluation French Benchmarks   | `make eval`       | `python run_eval.py --tasks EVAL_TASKS --model EVAL_MODEL`                                                                                 | `EVAL_TASKS=ifeval_fr`, `EVAL_MODEL=Qwen/Qwen3-0.6B`                              |
 
-⚠️ We use [lighteval](https://github.com/huggingface/lighteval) for evaluation, which may not be fully supported on Windows.
+⚠️ We use [Lighteval](https://github.com/huggingface/lighteval) and [vLLM](https://github.com/vllm-project/vllm) for evaluation.
 
 ## 3. Results
 
-| Model Name | IFEval-fr (strict prompt) | BBH-fr |
-|------------|-------------|-------------|
-| Qwen3-0.6B   | 20.53        |  34.13         |
-| Qwen3-0.6B-Base   |      -      |    40.85            |
+| Evaluation               | Qwen3-0.6B | Qwen3-0.6B-Base |
+|--------------------------|------------|-----------------|
+| IFEval-fr (strict prompt)| 20.53      | -               |
+| BBH-fr                   | 34.13      | 40.85           |
 
 
 ## 3. Resources:

--- a/README.md
+++ b/README.md
@@ -37,25 +37,25 @@ $env:HF_TOKEN="your_hf_token"
 
 ## 3. Results
 
-| Evaluation               | Qwen3-0.6B   | Qwen2.5-0.5B-Instruct | LFM2-700M |
-|--------------------------|--------------|-----------------------|-----------|
-| IFEval-fr (strict prompt)|              |                       |           |
-| GPQA-Diamond-fr          |              |                       |           |
-| BoolQ-fr                 |              |  1.12                 |           |
-| Math-Hard-fr             |              |                       |           |
-| MMLU-fr                  |              |                       |           |
-| BBH-fr                   |              |                       |           |
-| MuSR-fr                  |              |                       |           |
+| Evaluation               | Qwen3-0.6B   | Qwen2.5-0.5B-Instruct |
+|--------------------------|--------------|-----------------------|
+| IFEval-fr (strict prompt)|              |  18.43                |
+| GPQA-Diamond-fr          |              |  35.84                |
+| BoolQ-fr                 |              |  0.00                 |
+| Math-Hard-fr             |              |  1.40                 |
+| MMLU-fr                  |              |  35.37                |
+| BBH-fr                   |              |  42.33                |
+| MuSR-fr                  |              |  37.49                |
 
-| Evaluation               | Qwen2.5-1.5B-Instruct | DeepSeek-R1-Distill-Qwen-1.5B | Qwen3-1.7B | LFM2-1.2B    |
-|--------------------------|--------------|-------------------------------|------------|--------------|
-| IFEval-fr (strict prompt)|              |                               |            |              |
-| GPQA-Diamond-fr          |              |                               |            |              |
-| BoolQ-fr                 |              |                               |            |              |
-| Math-Hard-fr             |              |                               |            |              |
-| MMLU-fr                  |              |                               |            |              |
-| BBH-fr                   |              |                               |            |              |
-| MuSR-fr                  |              |                               |            |              |
+| Evaluation               | Qwen2.5-1.5B-Instruct | DeepSeek-R1-Distill-Qwen-1.5B | Qwen3-1.7B |
+|--------------------------|-----------------------|-------------------------------|------------|
+| IFEval-fr (strict prompt)|    26.63              |                               |            |
+| GPQA-Diamond-fr          |    30.07              |                               |            |
+| BoolQ-fr                 |    70.39              |                               |            |
+| Math-Hard-fr             |    4.64               |                               |            |
+| MMLU-fr                  |    48,17              |                               |            |
+| BBH-fr                   |    47.57              |                               |            |
+| MuSR-fr                  |    37.47              |                               |            |
 
 ## 3. Resources:
 - [French LLM Leaderboard](https://huggingface.co/spaces/fr-gouv-coordination-ia/llm_leaderboard_fr#/)

--- a/README.md
+++ b/README.md
@@ -31,24 +31,31 @@ $env:HF_TOKEN="your_hf_token"
 
 | Task        | Make Command       | Equivalent CLI Command                                                                                                                                               | Default Values                                                                 |
 |-------------|--------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------|
-| Evaluation French Benchmarks   | `make eval`       | `python run_eval.py --tasks EVAL_TASKS --model EVAL_MODEL`                                                                                 | `EVAL_TASKS=ifeval_fr`, `EVAL_MODEL=Qwen/Qwen2.5-1.5B-Instruct`                              |
+| Evaluation French Benchmarks   | `make eval`       | `python src/eval/eval.py --tasks EVAL_TASKS --model EVAL_MODEL`                                                                                 | `EVAL_TASKS=ifeval-fr`, `EVAL_MODEL=Qwen/Qwen2.5-1.5B-Instruct`                              |
 
 ⚠️ We use [Lighteval](https://github.com/huggingface/lighteval) and [vLLM](https://github.com/vllm-project/vllm) for evaluation.
 
 ## 3. Results
 
-Parameters: `Temperature=0.0`
+| Evaluation               | Qwen3-0.6B   | Qwen2.5-0.5B-Instruct | LFM2-700M |
+|--------------------------|--------------|-----------------------|-----------|
+| IFEval-fr (strict prompt)|              |                       |           |
+| GPQA-Diamond-fr          |              |                       |           |
+| BoolQ-fr                 |              |  1.12                 |           |
+| Math-Hard-fr             |              |                       |           |
+| MMLU-fr                  |              |                       |           |
+| BBH-fr                   |              |                       |           |
+| MuSR-fr                  |              |                       |           |
 
-| Evaluation               | Qwen2.5-1.5B | 
-|--------------------------|--------------|
-| IFEval-fr (strict prompt)| 23.78        |
-| GPQA-Diamond-fr          | 29.02        |
-| BoolQ-fr                 | 69.3         | 
-| Math-Hard-fr             | 4.77         | 
-| MMLU-fr                  | 48.17        | 
-| BBH-fr                   | 49.64        | 
-| MuSR-fr                  | 37.47        | 
-
+| Evaluation               | Qwen2.5-1.5B-Instruct | DeepSeek-R1-Distill-Qwen-1.5B | Qwen3-1.7B | LFM2-1.2B    |
+|--------------------------|--------------|-------------------------------|------------|--------------|
+| IFEval-fr (strict prompt)|              |                               |            |              |
+| GPQA-Diamond-fr          |              |                               |            |              |
+| BoolQ-fr                 |              |                               |            |              |
+| Math-Hard-fr             |              |                               |            |              |
+| MMLU-fr                  |              |                               |            |              |
+| BBH-fr                   |              |                               |            |              |
+| MuSR-fr                  |              |                               |            |              |
 
 ## 3. Resources:
 - [French LLM Leaderboard](https://huggingface.co/spaces/fr-gouv-coordination-ia/llm_leaderboard_fr#/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,13 +7,15 @@ name = "french-slm"
 version = "0.1.0"
 description = "French SLM."
 authors = [
-  { name = "KuraKura AI"},
+  {name = "KuraKura AI"},
 ]
-requires-python = "==3.12.*"
+requires-python = "==3.10.*"
 dependencies = [
-  "transformers==4.51.3",
-  "datasets==3.5.0",
-  "wandb==0.19.11"
+  "lighteval==0.10.0",
+  "vllm==0.9.1",
+  "ray==2.47.1",
+  "more-itertools==10.7.0",
+  "wandb==0.19.11",
 ]
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 requires-python = "==3.10.*"
 dependencies = [
-  "lighteval==0.10.0",
+  "lighteval[extended_tasks]==0.10.0",
   "vllm==0.9.1",
   "ray==2.47.1",
   "more-itertools==10.7.0",

--- a/src/eval/eval.py
+++ b/src/eval/eval.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from lighteval.logging.evaluation_tracker import EvaluationTracker
 from lighteval.models.vllm.vllm_model import VLLMModelConfig
 from lighteval.pipeline import ParallelismManager, Pipeline, PipelineParameters
-from lighteval.models.utils import GenerationParameters
+from model_params import MODEL_PARAMS
 import argparse
 import nltk
 
@@ -55,9 +55,10 @@ def main(args):
         custom_tasks_directory=tasks_path,
     )
 
-    generation_params = GenerationParameters(
-        temperature=args.temperature,  # Set temperature to 0 for deterministic outputs
-    )
+    generation_params = None
+    if args.model in MODEL_PARAMS:
+        generation_params = MODEL_PARAMS[args.model]
+
     model_config = VLLMModelConfig(
         model_name=args.model,
         dtype="bfloat16",
@@ -105,12 +106,6 @@ if __name__ == "__main__":
         type=str,
         default="Qwen/Qwen3-0.6B",
         help="Model name to use for evaluation.",
-    )
-    parser.add_argument(
-        "--temperature",
-        type=float,
-        default=0.0,
-        help="Temperature for model generation.",
     )
     args = parser.parse_args()
     main(args)

--- a/src/eval/eval.py
+++ b/src/eval/eval.py
@@ -7,11 +7,17 @@ from lighteval.models.utils import GenerationParameters
 import argparse
 import nltk
 
+# Match Hard
+# https://github.com/hitachi-nlp/lm-evaluation-harness/blob/NeurIPS_2024/lm_eval/tasks/leaderboard/math/utils.py
+# https://arxiv.org/pdf/2206.14858
+# https://github.com/wellecks/lm-evaluation-harness/blob/master/lm_eval/tasks/minerva_math.py
+
 
 TASKS_REFS = {
     "ifeval-fr": "community|ifeval-fr|0|0",
     "gpqa-fr": "community|gpqa-fr|0|0",
     "bbh-fr": "community|bbh-fr|0|0",
+    "math-hard-fr": "community|math-hard-fr|0|0",  # 4 shots under the hood
 }
 
 
@@ -78,7 +84,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--tasks",
         nargs="+",
-        choices=["ifeval-fr", "gpqa-fr", "bbh-fr"],
+        choices=["ifeval-fr", "gpqa-fr", "bbh-fr", "math-hard-fr"],
         required=True,
         help="Tasks to evaluate the model.",
     )

--- a/src/eval/eval.py
+++ b/src/eval/eval.py
@@ -13,6 +13,8 @@ TASKS_REFS = {
     "gpqa-fr": "community|gpqa-fr|0|0",
     "bbh-fr": "community|bbh-fr|0|0",
     "boolq-fr": "community|boolq-fr|0|0",
+    "mmlu-fr": "community|mmlu_fr|0|0",
+    "musr-fr": "community|musr-fr|0|0",
     "math-hard-fr": "community|math-hard-fr|0|0",  # 4 shots under the hood
 }
 
@@ -80,7 +82,15 @@ if __name__ == "__main__":
     parser.add_argument(
         "--tasks",
         nargs="+",
-        choices=["ifeval-fr", "gpqa-fr", "bbh-fr", "boolq-fr", "math-hard-fr"],
+        choices=[
+            "ifeval-fr",
+            "gpqa-fr",
+            "bbh-fr",
+            "boolq-fr",
+            "mmlu-fr",
+            "musr-fr",
+            "math-hard-fr",
+        ],
         required=True,
         help="Tasks to evaluate the model.",
     )

--- a/src/eval/eval.py
+++ b/src/eval/eval.py
@@ -10,7 +10,7 @@ import nltk
 
 TASKS_REFS = {
     "ifeval-fr": "community|ifeval-fr|0|0",
-    "gpqa-fr": "community|gpqa-fr|0|0",
+    "gpqa-diamond-fr": "community|gpqa-diamond-fr|0|0",
     "bbh-fr": "community|bbh-fr|0|0",
     "boolq-fr": "community|boolq-fr|0|0",
     "mmlu-fr": "community|mmlu_fr|0|0",
@@ -56,12 +56,12 @@ def main(args):
     )
 
     generation_params = GenerationParameters(
-        temperature=0.0,  # Set temperature to 0 for deterministic outputs
+        temperature=args.temperature,  # Set temperature to 0 for deterministic outputs
     )
     model_config = VLLMModelConfig(
         model_name=args.model,
         dtype="bfloat16",
-        use_chat_template=False,
+        use_chat_template=True,
         generation_parameters=generation_params,
     )
 
@@ -84,7 +84,7 @@ if __name__ == "__main__":
         nargs="+",
         choices=[
             "ifeval-fr",
-            "gpqa-fr",
+            "gpqa-diamond-fr",
             "bbh-fr",
             "boolq-fr",
             "mmlu-fr",
@@ -105,6 +105,12 @@ if __name__ == "__main__":
         type=str,
         default="Qwen/Qwen3-0.6B",
         help="Model name to use for evaluation.",
+    )
+    parser.add_argument(
+        "--temperature",
+        type=float,
+        default=0.0,
+        help="Temperature for model generation.",
     )
     args = parser.parse_args()
     main(args)

--- a/src/eval/eval.py
+++ b/src/eval/eval.py
@@ -6,16 +6,30 @@ from lighteval.pipeline import ParallelismManager, Pipeline, PipelineParameters
 import argparse
 import nltk
 
+from french_evals import TASKS_TABLE
+
 # https://github.com/leaderboard-modeles-IA-francais/evaluation-pipeline-leaderboard/blob/main/run-lighteval.py
 
 
-def get_tasks(tasks):
-    task_lookup = {
-        "ifeval_fr": "community|ifeval-fr|0|0",
-        "gpqa_fr": "community|gpqa-fr|0|0",
-    }
-    selected_tasks = ",".join([task_lookup[t] for t in tasks])
-    return selected_tasks
+def get_tasks(task_keys):
+    """
+    Build the comma-separated task specifier strings for given task keys.
+    """
+    selected = []
+    for key in task_keys:
+        if key == "bbh-fr":
+            for task in TASKS_TABLE:
+                # each task has .name and .suite attributes
+                if hasattr(task, "name") and hasattr(task, "suite"):
+                    if task.name.startswith("bbh-fr:") and "community" in task.suite:
+                        selected.append(f"community|{task.name}|0|0")
+        elif key == "ifeval_fr":
+            selected.append("community|ifeval-fr|0|0")
+        elif key == "gpqa_fr":
+            selected.append("community|gpqa-fr|0|0")
+        else:
+            raise ValueError(f"Unknown task key: {key}")
+    return ",".join(selected)
 
 
 def main(args):
@@ -71,8 +85,8 @@ if __name__ == "__main__":
     parser.add_argument(
         "--tasks",
         nargs="+",
-        choices=["ifeval_fr", "gpqa_fr"],
-        default="ifeval_fr",
+        choices=["ifeval_fr", "gpqa_fr", "bbh-fr"],
+        required=True,
         help="Tasks to evaluate the model.",
     )
     parser.add_argument(

--- a/src/eval/eval.py
+++ b/src/eval/eval.py
@@ -7,16 +7,12 @@ from lighteval.models.utils import GenerationParameters
 import argparse
 import nltk
 
-# Match Hard
-# https://github.com/hitachi-nlp/lm-evaluation-harness/blob/NeurIPS_2024/lm_eval/tasks/leaderboard/math/utils.py
-# https://arxiv.org/pdf/2206.14858
-# https://github.com/wellecks/lm-evaluation-harness/blob/master/lm_eval/tasks/minerva_math.py
-
 
 TASKS_REFS = {
     "ifeval-fr": "community|ifeval-fr|0|0",
     "gpqa-fr": "community|gpqa-fr|0|0",
     "bbh-fr": "community|bbh-fr|0|0",
+    "boolq-fr": "community|boolq-fr|0|0",
     "math-hard-fr": "community|math-hard-fr|0|0",  # 4 shots under the hood
 }
 
@@ -84,7 +80,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--tasks",
         nargs="+",
-        choices=["ifeval-fr", "gpqa-fr", "bbh-fr", "math-hard-fr"],
+        choices=["ifeval-fr", "gpqa-fr", "bbh-fr", "boolq-fr", "math-hard-fr"],
         required=True,
         help="Tasks to evaluate the model.",
     )

--- a/src/eval/eval.py
+++ b/src/eval/eval.py
@@ -1,0 +1,91 @@
+import os
+from pathlib import Path
+from lighteval.logging.evaluation_tracker import EvaluationTracker
+from lighteval.models.vllm.vllm_model import VLLMModelConfig
+from lighteval.pipeline import ParallelismManager, Pipeline, PipelineParameters
+import argparse
+import nltk
+
+# https://github.com/leaderboard-modeles-IA-francais/evaluation-pipeline-leaderboard/blob/main/run-lighteval.py
+
+
+def get_tasks(tasks):
+    task_lookup = {
+        "ifeval_fr": "community|ifeval-fr|0|0",
+        "gpqa_fr": "community|gpqa-fr|0|0",
+    }
+    selected_tasks = ",".join([task_lookup[t] for t in tasks])
+    return selected_tasks
+
+
+def main(args):
+    """
+    Main function to run the evaluation pipeline with vLLM backend.
+    """
+
+    if os.environ.get("HF_TOKEN") is None:
+        raise ValueError(
+            "Please set the HF_TOKEN environment variable to your Hugging Face token."
+        )
+
+    try:
+        nltk.data.find("tokenizers/punkt")
+    except LookupError:
+        print("Downloading NLTK punkt tokenizer...")
+        nltk.download("punkt_tab")
+
+    tasks_path = Path(f"src/eval/french_evals.py")
+
+    evaluation_tracker = EvaluationTracker(
+        output_dir=args.output_dir,
+        save_details=True,
+        push_to_hub=False,
+    )
+
+    pipeline_params = PipelineParameters(
+        launcher_type=ParallelismManager.VLLM,
+        custom_tasks_directory=tasks_path,
+    )
+
+    # Can add more parameters here
+    model_config = VLLMModelConfig(
+        model_name=args.model,
+        dtype="bfloat16",
+        use_chat_template=True,
+    )
+
+    pipeline = Pipeline(
+        tasks=get_tasks(args.tasks),
+        pipeline_parameters=pipeline_params,
+        evaluation_tracker=evaluation_tracker,
+        model_config=model_config,
+    )
+
+    pipeline.evaluate()
+    pipeline.save_and_push_results()
+    pipeline.show_results()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Run evaluation with vLLM backend.")
+    parser.add_argument(
+        "--tasks",
+        nargs="+",
+        choices=["ifeval_fr", "gpqa_fr"],
+        default="ifeval_fr",
+        help="Tasks to evaluate the model.",
+    )
+    parser.add_argument(
+        "--output_dir",
+        type=str,
+        default="./results_french_evals",
+        help="Directory to save evaluation results.",
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        default="Qwen/Qwen3-0.6B",
+        help="Model name to use for evaluation.",
+    )
+    args = parser.parse_args()
+    main(args)

--- a/src/eval/french_evals.py
+++ b/src/eval/french_evals.py
@@ -1,0 +1,143 @@
+# MIT License
+
+# Copyright (c) 2024 The HuggingFace Team
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# ruff: noqa: F405, F403, F401
+"""
+Custom evaluation tasks for lighteval.
+
+This file generally creates just a TASKS_TABLE and TASKS_GROUPS which are then imported by LightEval.
+
+This module implements tasks for the french specific datasets
+See : https://huggingface.co/fr-gouv-coordination-ia
+"""
+
+import random
+
+from lighteval.metrics.metrics import Metrics
+from lighteval.tasks.default_prompts import LETTER_INDICES
+from lighteval.tasks.extended.ifeval.main import ifeval_metrics
+from lighteval.tasks.lighteval_task import LightevalTaskConfig
+from lighteval.tasks.requests import Doc
+from lighteval.utils.utils import as_list
+
+
+# Ifeval-fr prompt function
+def prompt_ifeval_fr(line, task_name: str = None):
+    return Doc(
+        task_name=task_name,
+        query=line["prompt"],
+        choices=[""],
+        gold_index=0,
+        instruction="",
+        specific={
+            "instructions_id_list": line["instruction_id_list"],
+            "kwargs": line["kwargs"],
+        },
+    )
+
+
+# qpqa-fr prompt function
+def prompt_gpqa_fr(line, task_name: str = None):
+    gold_index = random.randint(0, 3)
+    choices = [
+        line["Réponse incorrecte 1"],
+        line["Réponse incorrecte 2"],
+        line["Réponse incorrecte 3"],
+    ]
+    choices.insert(gold_index, line["Réponse correcte"])
+
+    instruction = "Choisissez la réponse correcte aux questions suivantes.\n\n"
+
+    query = f"Question: {line['Question']}\n"
+    query += "".join(
+        [f"{key}. {choice}\n" for key, choice in zip(LETTER_INDICES, choices)]
+    )
+    query += "Réponse: "
+    return Doc(
+        task_name=task_name,
+        query=f"{instruction}{query}",
+        choices=LETTER_INDICES[: len(choices)],
+        gold_index=gold_index,
+        instruction=instruction,
+    )
+
+
+# BAC-fr prompt function
+def prompt_bac_fr(line, task_name: str = None):
+    prompt = f"Enoncé: {line['enonce']}\n{line['instruction']}\n"
+    if line["choix"] is not None:  # Multichoice evaluation
+        # prompt += "\n".join([f"{LETTER_INDICES[ix]}.{choix}" for ix, choix in enumerate(line["choix"])])
+        return Doc(
+            task_name=task_name,
+            query=prompt,
+            choices=as_list(line["choix"]),
+            gold_index=line["choix"].index(line["choix correct"]),
+            instruction="",
+        )
+    else:
+        return Doc(
+            task_name=task_name,
+            query=prompt,
+            choices=[line["reponse"]],
+            gold_index=0,
+            instruction="",
+        )
+
+
+# IFEVal-fr task
+ifeval_fr_task = LightevalTaskConfig(
+    name="ifeval-fr",
+    prompt_function=prompt_ifeval_fr,
+    suite=["community"],
+    hf_repo="jzhang86/fr_ifeval",
+    hf_subset="default",
+    metric=[ifeval_metrics],
+    hf_avail_splits=["train"],
+    evaluation_splits=["train"],
+    few_shots_split="train",
+    few_shots_select="random_sampling",
+    generation_size=1280,
+    stop_sequence=[],  # no stop sequence, will use eot token
+    version="0.1",
+)
+
+# GPQA-fr task
+gpqa_fr_task = LightevalTaskConfig(
+    name="gpqa-fr",
+    suite=["community"],
+    prompt_function=prompt_gpqa_fr,
+    hf_repo="le-leadboard/gpqa-fr",
+    hf_subset="default",
+    hf_avail_splits=["train"],
+    evaluation_splits=["train"],
+    few_shots_split=None,
+    few_shots_select="random_sampling",
+    generation_size=1,
+    metric=[Metrics.loglikelihood_acc],
+    stop_sequence=["\n"],
+    trust_dataset=True,
+    version=0,
+)
+
+
+# STORE YOUR EVALS
+TASKS_TABLE = [ifeval_fr_task, gpqa_fr_task]

--- a/src/eval/french_evals.py
+++ b/src/eval/french_evals.py
@@ -30,83 +30,16 @@ This module implements tasks for the french specific datasets
 See : https://huggingface.co/fr-gouv-coordination-ia
 """
 
-import random
-
 from lighteval.metrics.metrics import Metrics
-from lighteval.tasks.default_prompts import LETTER_INDICES
 from lighteval.tasks.extended.ifeval.main import ifeval_metrics
 from lighteval.tasks.lighteval_task import LightevalTaskConfig
-from lighteval.tasks.requests import Doc
-from lighteval.utils.utils import as_list
-
-
-# Ifeval-fr prompt function
-def prompt_ifeval_fr(line, task_name: str = None):
-    return Doc(
-        task_name=task_name,
-        query=line["prompt"],
-        choices=[""],
-        gold_index=0,
-        instruction="",
-        specific={
-            "instructions_id_list": line["instruction_id_list"],
-            "kwargs": line["kwargs"],
-        },
-    )
-
-
-# qpqa-fr prompt function
-def prompt_gpqa_fr(line, task_name: str = None):
-    gold_index = random.randint(0, 3)
-    choices = [
-        line["Réponse incorrecte 1"],
-        line["Réponse incorrecte 2"],
-        line["Réponse incorrecte 3"],
-    ]
-    choices.insert(gold_index, line["Réponse correcte"])
-
-    instruction = "Choisissez la réponse correcte aux questions suivantes.\n\n"
-
-    query = f"Question: {line['Question']}\n"
-    query += "".join(
-        [f"{key}. {choice}\n" for key, choice in zip(LETTER_INDICES, choices)]
-    )
-    query += "Réponse: "
-    return Doc(
-        task_name=task_name,
-        query=f"{instruction}{query}",
-        choices=LETTER_INDICES[: len(choices)],
-        gold_index=gold_index,
-        instruction=instruction,
-    )
-
-
-# BAC-fr prompt function
-def prompt_bac_fr(line, task_name: str = None):
-    prompt = f"Enoncé: {line['enonce']}\n{line['instruction']}\n"
-    if line["choix"] is not None:  # Multichoice evaluation
-        # prompt += "\n".join([f"{LETTER_INDICES[ix]}.{choix}" for ix, choix in enumerate(line["choix"])])
-        return Doc(
-            task_name=task_name,
-            query=prompt,
-            choices=as_list(line["choix"]),
-            gold_index=line["choix"].index(line["choix correct"]),
-            instruction="",
-        )
-    else:
-        return Doc(
-            task_name=task_name,
-            query=prompt,
-            choices=[line["reponse"]],
-            gold_index=0,
-            instruction="",
-        )
+import prompts as prompt
 
 
 # IFEVal-fr task
 ifeval_fr_task = LightevalTaskConfig(
     name="ifeval-fr",
-    prompt_function=prompt_ifeval_fr,
+    prompt_function=prompt.prompt_ifeval_fr,
     suite=["community"],
     hf_repo="jzhang86/fr_ifeval",
     hf_subset="default",
@@ -124,12 +57,12 @@ ifeval_fr_task = LightevalTaskConfig(
 gpqa_fr_task = LightevalTaskConfig(
     name="gpqa-fr",
     suite=["community"],
-    prompt_function=prompt_gpqa_fr,
+    prompt_function=prompt.prompt_gpqa_fr,
     hf_repo="le-leadboard/gpqa-fr",
     hf_subset="default",
     hf_avail_splits=["train"],
     evaluation_splits=["train"],
-    few_shots_split=None,
+    few_shots_split="train",
     few_shots_select="random_sampling",
     generation_size=1,
     metric=[Metrics.loglikelihood_acc],
@@ -138,6 +71,631 @@ gpqa_fr_task = LightevalTaskConfig(
     version=0,
 )
 
+# BigBench Hard task
+bbh_boolean_expressions_community = LightevalTaskConfig(
+    name="bbh-fr:expressions_booléennes",
+    suite=["community"],
+    prompt_function=prompt.bbh_boolean_expressions,
+    hf_repo="le-leadboard/bbh-fr",
+    hf_subset="expressions_booléennes",
+    hf_avail_splits=["test"],
+    evaluation_splits=["test"],
+    few_shots_split="train",
+    few_shots_select="random",
+    generation_size=20,
+    metric=[
+        Metrics.exact_match,
+        Metrics.quasi_exact_match,
+        Metrics.prefix_exact_match,
+        Metrics.prefix_quasi_exact_match,
+        Metrics.perfect_exact_match,
+    ],
+    stop_sequence=["</s>", "Q=", "\n\n"],
+    trust_dataset=True,
+    version=0,
+)
+bbh_causal_judgment_community = LightevalTaskConfig(
+    name="bbh-fr:jugement_causal",
+    suite=["community"],
+    prompt_function=prompt.bbh_causal_judgment,
+    hf_repo="le-leadboard/bbh-fr",
+    hf_subset="jugement_causal",
+    hf_avail_splits=["test"],
+    evaluation_splits=["test"],
+    few_shots_split="train",
+    few_shots_select="random",
+    generation_size=20,
+    metric=[
+        Metrics.exact_match,
+        Metrics.quasi_exact_match,
+        Metrics.prefix_exact_match,
+        Metrics.prefix_quasi_exact_match,
+        Metrics.perfect_exact_match,
+    ],
+    stop_sequence=["</s>", "Q=", "\n\n"],
+    trust_dataset=True,
+    version=0,
+)
+bbh_date_understanding_community = LightevalTaskConfig(
+    name="bbh-fr:compréhension_de_la_date",
+    suite=["community"],
+    prompt_function=prompt.bbh_date_understanding,
+    hf_repo="le-leadboard/bbh-fr",
+    hf_subset="compréhension_de_la_date",
+    hf_avail_splits=["test"],
+    evaluation_splits=["test"],
+    few_shots_split="train",
+    few_shots_select="random",
+    generation_size=20,
+    metric=[
+        Metrics.exact_match,
+        Metrics.quasi_exact_match,
+        Metrics.prefix_exact_match,
+        Metrics.prefix_quasi_exact_match,
+        Metrics.perfect_exact_match,
+    ],
+    stop_sequence=["</s>", "Q=", "\n\n"],
+    trust_dataset=True,
+    version=0,
+)
+bbh_disambiguation_qa_community = LightevalTaskConfig(
+    name="bbh-fr:désambiguïsation_qa",
+    suite=["community"],
+    prompt_function=prompt.bbh_disambiguation_qa,
+    hf_repo="le-leadboard/bbh-fr",
+    hf_subset="désambiguïsation_qa",
+    hf_avail_splits=["test"],
+    evaluation_splits=["test"],
+    few_shots_split="train",
+    few_shots_select="random",
+    generation_size=20,
+    metric=[
+        Metrics.exact_match,
+        Metrics.quasi_exact_match,
+        Metrics.prefix_exact_match,
+        Metrics.prefix_quasi_exact_match,
+        Metrics.perfect_exact_match,
+    ],
+    stop_sequence=["</s>", "Q=", "\n\n"],
+    trust_dataset=True,
+    version=0,
+)
+bbh_dyck_languages_community = LightevalTaskConfig(
+    name="bbh-fr:dyck_languages",
+    suite=["community"],
+    prompt_function=prompt.bbh_dyck_languages,
+    hf_repo="le-leadboard/bbh-fr",
+    hf_subset="dyck_languages",
+    hf_avail_splits=["test"],
+    evaluation_splits=["test"],
+    few_shots_split="train",
+    few_shots_select="random",
+    generation_size=20,
+    metric=[
+        Metrics.exact_match,
+        Metrics.quasi_exact_match,
+        Metrics.prefix_exact_match,
+        Metrics.prefix_quasi_exact_match,
+        Metrics.perfect_exact_match,
+    ],
+    stop_sequence=["</s>", "Q=", "\n\n"],
+    trust_dataset=True,
+    version=0,
+)
+bbh_formal_fallacies_community = LightevalTaskConfig(
+    name="bbh-fr:sophismes_formels",
+    suite=["community"],
+    prompt_function=prompt.bbh_formal_fallacies,
+    hf_repo="le-leadboard/bbh-fr",
+    hf_subset="sophismes_formels",
+    hf_avail_splits=["test"],
+    evaluation_splits=["test"],
+    few_shots_split="train",
+    few_shots_select="random",
+    generation_size=20,
+    metric=[
+        Metrics.exact_match,
+        Metrics.quasi_exact_match,
+        Metrics.prefix_exact_match,
+        Metrics.prefix_quasi_exact_match,
+        Metrics.perfect_exact_match,
+    ],
+    stop_sequence=["</s>", "Q=", "\n\n"],
+    trust_dataset=True,
+    version=0,
+)
+bbh_geometric_shapes_community = LightevalTaskConfig(
+    name="bbh-fr:formes_géométriques",
+    suite=["community"],
+    prompt_function=prompt.bbh_geometric_shapes,
+    hf_repo="le-leadboard/bbh-fr",
+    hf_subset="formes_géométriques",
+    hf_avail_splits=["test"],
+    evaluation_splits=["test"],
+    few_shots_split="train",
+    few_shots_select="random",
+    generation_size=20,
+    metric=[
+        Metrics.exact_match,
+        Metrics.quasi_exact_match,
+        Metrics.prefix_exact_match,
+        Metrics.prefix_quasi_exact_match,
+        Metrics.perfect_exact_match,
+    ],
+    stop_sequence=["</s>", "Q=", "\n\n"],
+    trust_dataset=True,
+    version=0,
+)
+bbh_hyperbaton_community = LightevalTaskConfig(
+    name="bbh-fr:hyperbate",
+    suite=["community"],
+    prompt_function=prompt.bbh_hyperbaton,
+    hf_repo="le-leadboard/bbh-fr",
+    hf_subset="hyperbate",
+    hf_avail_splits=["test"],
+    evaluation_splits=["test"],
+    few_shots_split="train",
+    few_shots_select="random",
+    generation_size=20,
+    metric=[
+        Metrics.exact_match,
+        Metrics.quasi_exact_match,
+        Metrics.prefix_exact_match,
+        Metrics.prefix_quasi_exact_match,
+        Metrics.perfect_exact_match,
+    ],
+    stop_sequence=["</s>", "Q=", "\n\n"],
+    trust_dataset=True,
+    version=0,
+)
+bbh_logical_deduction_five_objects_community = LightevalTaskConfig(
+    name="bbh-fr:suivi_objets_mélangés_cinq_objets",
+    suite=["community"],
+    prompt_function=prompt.bbh_logical_deduction_five_objects,
+    hf_repo="le-leadboard/bbh-fr",
+    hf_subset="suivi_objets_mélangés_cinq_objets",
+    hf_avail_splits=["test"],
+    evaluation_splits=["test"],
+    few_shots_split="train",
+    few_shots_select="random",
+    generation_size=20,
+    metric=[
+        Metrics.exact_match,
+        Metrics.quasi_exact_match,
+        Metrics.prefix_exact_match,
+        Metrics.prefix_quasi_exact_match,
+        Metrics.perfect_exact_match,
+    ],
+    stop_sequence=["</s>", "Q=", "\n\n"],
+    trust_dataset=True,
+    version=0,
+)
+bbh_logical_deduction_seven_objects_community = LightevalTaskConfig(
+    name="bbh-fr:déduction_logique_sept_objets",
+    suite=["community"],
+    prompt_function=prompt.bbh_logical_deduction_seven_objects,
+    hf_repo="le-leadboard/bbh-fr",
+    hf_subset="déduction_logique_sept_objets",
+    hf_avail_splits=["test"],
+    evaluation_splits=["test"],
+    few_shots_split="train",
+    few_shots_select="random",
+    generation_size=20,
+    metric=[
+        Metrics.exact_match,
+        Metrics.quasi_exact_match,
+        Metrics.prefix_exact_match,
+        Metrics.prefix_quasi_exact_match,
+        Metrics.perfect_exact_match,
+    ],
+    stop_sequence=["</s>", "Q=", "\n\n"],
+    trust_dataset=True,
+    version=0,
+)
+bbh_logical_deduction_three_objects_community = LightevalTaskConfig(
+    name="bbh-fr:déduction_logique_trois_objets",
+    suite=["community"],
+    prompt_function=prompt.bbh_logical_deduction_three_objects,
+    hf_repo="le-leadboard/bbh-fr",
+    hf_subset="déduction_logique_trois_objets",
+    hf_avail_splits=["test"],
+    evaluation_splits=["test"],
+    few_shots_split="train",
+    few_shots_select="random",
+    generation_size=20,
+    metric=[
+        Metrics.exact_match,
+        Metrics.quasi_exact_match,
+        Metrics.prefix_exact_match,
+        Metrics.prefix_quasi_exact_match,
+        Metrics.perfect_exact_match,
+    ],
+    stop_sequence=["</s>", "Q=", "\n\n"],
+    trust_dataset=True,
+    version=0,
+)
+bbh_movie_recommendation_community = LightevalTaskConfig(
+    name="bbh-fr:recommandation_de_film",
+    suite=["community"],
+    prompt_function=prompt.bbh_movie_recommendation,
+    hf_repo="le-leadboard/bbh-fr",
+    hf_subset="recommandation_de_film",
+    hf_avail_splits=["test"],
+    evaluation_splits=["test"],
+    few_shots_split="train",
+    few_shots_select="random",
+    generation_size=20,
+    metric=[
+        Metrics.exact_match,
+        Metrics.quasi_exact_match,
+        Metrics.prefix_exact_match,
+        Metrics.prefix_quasi_exact_match,
+        Metrics.perfect_exact_match,
+    ],
+    stop_sequence=["</s>", "Q=", "\n\n"],
+    trust_dataset=True,
+    version=0,
+)
+bbh_multistep_arithmetic_two_community = LightevalTaskConfig(
+    name="bbh-fr:multistep_arithmetic_two",
+    suite=["community"],
+    prompt_function=prompt.bbh_multistep_arithmetic_two,
+    hf_repo="le-leadboard/bbh-fr",
+    hf_subset="multistep_arithmetic_two",
+    hf_avail_splits=["test"],
+    evaluation_splits=["test"],
+    few_shots_split="train",
+    few_shots_select="random",
+    generation_size=20,
+    metric=[
+        Metrics.exact_match,
+        Metrics.quasi_exact_match,
+        Metrics.prefix_exact_match,
+        Metrics.prefix_quasi_exact_match,
+        Metrics.perfect_exact_match,
+    ],
+    stop_sequence=["</s>", "Q=", "\n\n"],
+    trust_dataset=True,
+    version=0,
+)
+bbh_navigate_community = LightevalTaskConfig(
+    name="bbh-fr:naviguer",
+    suite=["community"],
+    prompt_function=prompt.bbh_navigate,
+    hf_repo="le-leadboard/bbh-fr",
+    hf_subset="naviguer",
+    hf_avail_splits=["test"],
+    evaluation_splits=["test"],
+    few_shots_split="train",
+    few_shots_select="random",
+    generation_size=20,
+    metric=[
+        Metrics.exact_match,
+        Metrics.quasi_exact_match,
+        Metrics.prefix_exact_match,
+        Metrics.prefix_quasi_exact_match,
+        Metrics.perfect_exact_match,
+    ],
+    stop_sequence=["</s>", "Q=", "\n\n"],
+    trust_dataset=True,
+    version=0,
+)
+bbh_object_counting_community = LightevalTaskConfig(
+    name="bbh-fr:comptage_d_objets",
+    suite=["community"],
+    prompt_function=prompt.bbh_object_counting,
+    hf_repo="le-leadboard/bbh-fr",
+    hf_subset="comptage_d_objets",
+    hf_avail_splits=["test"],
+    evaluation_splits=["test"],
+    few_shots_split="train",
+    few_shots_select="random",
+    generation_size=20,
+    metric=[
+        Metrics.exact_match,
+        Metrics.quasi_exact_match,
+        Metrics.prefix_exact_match,
+        Metrics.prefix_quasi_exact_match,
+        Metrics.perfect_exact_match,
+    ],
+    stop_sequence=["</s>", "Q=", "\n\n"],
+    trust_dataset=True,
+    version=0,
+)
+bbh_penguins_in_a_table_community = LightevalTaskConfig(
+    name="bbh-fr:pingouins_sur_une_table",
+    suite=["community"],
+    prompt_function=prompt.bbh_penguins_in_a_table,
+    hf_repo="le-leadboard/bbh-fr",
+    hf_subset="pingouins_sur_une_table",
+    hf_avail_splits=["test"],
+    evaluation_splits=["test"],
+    few_shots_split="train",
+    few_shots_select="random",
+    generation_size=20,
+    metric=[
+        Metrics.exact_match,
+        Metrics.quasi_exact_match,
+        Metrics.prefix_exact_match,
+        Metrics.prefix_quasi_exact_match,
+        Metrics.perfect_exact_match,
+    ],
+    stop_sequence=["</s>", "Q=", "\n\n"],
+    trust_dataset=True,
+    version=0,
+)
+bbh_reasoning_about_colored_objects_community = LightevalTaskConfig(
+    name="bbh-fr:raisonnement_sur_les_objets_colorés",
+    suite=["community"],
+    prompt_function=prompt.bbh_reasoning_about_colored_objects,
+    hf_repo="le-leadboard/bbh-fr",
+    hf_subset="raisonnement_sur_les_objets_colorés",
+    hf_avail_splits=["test"],
+    evaluation_splits=["test"],
+    few_shots_split="train",
+    few_shots_select="random",
+    generation_size=20,
+    metric=[
+        Metrics.exact_match,
+        Metrics.quasi_exact_match,
+        Metrics.prefix_exact_match,
+        Metrics.prefix_quasi_exact_match,
+        Metrics.perfect_exact_match,
+    ],
+    stop_sequence=["</s>", "Q=", "\n\n"],
+    trust_dataset=True,
+    version=0,
+)
+bbh_ruin_names_community = LightevalTaskConfig(
+    name="bbh-fr:noms_de_ruines",
+    suite=["community"],
+    prompt_function=prompt.bbh_ruin_names,
+    hf_repo="le-leadboard/bbh-fr",
+    hf_subset="noms_de_ruines",
+    hf_avail_splits=["test"],
+    evaluation_splits=["test"],
+    few_shots_split="train",
+    few_shots_select="random",
+    generation_size=20,
+    metric=[
+        Metrics.exact_match,
+        Metrics.quasi_exact_match,
+        Metrics.prefix_exact_match,
+        Metrics.prefix_quasi_exact_match,
+        Metrics.perfect_exact_match,
+    ],
+    stop_sequence=["</s>", "Q=", "\n\n"],
+    trust_dataset=True,
+    version=0,
+)
+bbh_salient_translation_error_detection_community = LightevalTaskConfig(
+    name="bbh-fr:détection_d_erreur_de_traduction_sailante",
+    suite=["community"],
+    prompt_function=prompt.bbh_salient_translation_error_detection,
+    hf_repo="le-leadboard/bbh-fr",
+    hf_subset="détection_d_erreur_de_traduction_sailante",
+    hf_avail_splits=["test"],
+    evaluation_splits=["test"],
+    few_shots_split="train",
+    few_shots_select="random",
+    generation_size=20,
+    metric=[
+        Metrics.exact_match,
+        Metrics.quasi_exact_match,
+        Metrics.prefix_exact_match,
+        Metrics.prefix_quasi_exact_match,
+        Metrics.perfect_exact_match,
+    ],
+    stop_sequence=["</s>", "Q=", "\n\n"],
+    trust_dataset=True,
+    version=0,
+)
+bbh_snarks_community = LightevalTaskConfig(
+    name="bbh-fr:sarcasmes",
+    suite=["community"],
+    prompt_function=prompt.bbh_snarks,
+    hf_repo="le-leadboard/bbh-fr",
+    hf_subset="sarcasmes",
+    hf_avail_splits=["test"],
+    evaluation_splits=["test"],
+    few_shots_split="train",
+    few_shots_select="random",
+    generation_size=20,
+    metric=[
+        Metrics.exact_match,
+        Metrics.quasi_exact_match,
+        Metrics.prefix_exact_match,
+        Metrics.prefix_quasi_exact_match,
+        Metrics.perfect_exact_match,
+    ],
+    stop_sequence=["</s>", "Q=", "\n\n"],
+    trust_dataset=True,
+    version=0,
+)
+bbh_sports_understanding_community = LightevalTaskConfig(
+    name="bbh-fr:compréhension_des_sports",
+    suite=["community"],
+    prompt_function=prompt.bbh_sports_understanding,
+    hf_repo="le-leadboard/bbh-fr",
+    hf_subset="compréhension_des_sports",
+    hf_avail_splits=["test"],
+    evaluation_splits=["test"],
+    few_shots_split="train",
+    few_shots_select="random",
+    generation_size=20,
+    metric=[
+        Metrics.exact_match,
+        Metrics.quasi_exact_match,
+        Metrics.prefix_exact_match,
+        Metrics.prefix_quasi_exact_match,
+        Metrics.perfect_exact_match,
+    ],
+    stop_sequence=["</s>", "Q=", "\n\n"],
+    trust_dataset=True,
+    version=0,
+)
+bbh_temporal_sequences_community = LightevalTaskConfig(
+    name="bbh-fr:séquences_temporelles",
+    suite=["community"],
+    prompt_function=prompt.bbh_temporal_sequences,
+    hf_repo="le-leadboard/bbh-fr",
+    hf_subset="séquences_temporelles",
+    hf_avail_splits=["test"],
+    evaluation_splits=["test"],
+    few_shots_split="train",
+    few_shots_select="random",
+    generation_size=20,
+    metric=[
+        Metrics.exact_match,
+        Metrics.quasi_exact_match,
+        Metrics.prefix_exact_match,
+        Metrics.prefix_quasi_exact_match,
+        Metrics.perfect_exact_match,
+    ],
+    stop_sequence=["</s>", "Q=", "\n\n"],
+    trust_dataset=True,
+    version=0,
+)
+bbh_tracking_shuffled_objects_five_objects_community = LightevalTaskConfig(
+    name="bbh-fr:suivi_objets_mélangés_cinq_objets",
+    suite=["community"],
+    prompt_function=prompt.bbh_tracking_shuffled_objects_five_objects,
+    hf_repo="le-leadboard/bbh-fr",
+    hf_subset="suivi_objets_mélangés_cinq_objets",
+    hf_avail_splits=["test"],
+    evaluation_splits=["test"],
+    few_shots_split="train",
+    few_shots_select="random",
+    generation_size=20,
+    metric=[
+        Metrics.exact_match,
+        Metrics.quasi_exact_match,
+        Metrics.prefix_exact_match,
+        Metrics.prefix_quasi_exact_match,
+        Metrics.perfect_exact_match,
+    ],
+    stop_sequence=["</s>", "Q=", "\n\n"],
+    trust_dataset=True,
+    version=0,
+)
+bbh_tracking_shuffled_objects_seven_objects_community = LightevalTaskConfig(
+    name="bbh-fr:suivi_objets_mélangés_sept_objets",
+    suite=["community"],
+    prompt_function=prompt.bbh_tracking_shuffled_objects_seven_objects,
+    hf_repo="le-leadboard/bbh-fr",
+    hf_subset="suivi_objets_mélangés_sept_objets",
+    hf_avail_splits=["test"],
+    evaluation_splits=["test"],
+    few_shots_split="train",
+    few_shots_select="random",
+    generation_size=20,
+    metric=[
+        Metrics.exact_match,
+        Metrics.quasi_exact_match,
+        Metrics.prefix_exact_match,
+        Metrics.prefix_quasi_exact_match,
+        Metrics.perfect_exact_match,
+    ],
+    stop_sequence=["</s>", "Q=", "\n\n"],
+    trust_dataset=True,
+    version=0,
+)
+bbh_tracking_shuffled_objects_three_objects_community = LightevalTaskConfig(
+    name="bbh-fr:suivi_objets_mélangés_trois_objets",
+    suite=["community"],
+    prompt_function=prompt.bbh_tracking_shuffled_objects_three_objects,
+    hf_repo="le-leadboard/bbh-fr",
+    hf_subset="suivi_objets_mélangés_trois_objets",
+    hf_avail_splits=["test"],
+    evaluation_splits=["test"],
+    few_shots_split="train",
+    few_shots_select="random",
+    generation_size=20,
+    metric=[
+        Metrics.exact_match,
+        Metrics.quasi_exact_match,
+        Metrics.prefix_exact_match,
+        Metrics.prefix_quasi_exact_match,
+        Metrics.perfect_exact_match,
+    ],
+    stop_sequence=["</s>", "Q=", "\n\n"],
+    trust_dataset=True,
+    version=0,
+)
+bbh_web_of_lies_community = LightevalTaskConfig(
+    name="bbh-fr:toile_de_mensonges",
+    suite=["community"],
+    prompt_function=prompt.bbh_web_of_lies,
+    hf_repo="le-leadboard/bbh-fr",
+    hf_subset="toile_de_mensonges",
+    hf_avail_splits=["test"],
+    evaluation_splits=["test"],
+    few_shots_split="train",
+    few_shots_select="random",
+    generation_size=20,
+    metric=[
+        Metrics.exact_match,
+        Metrics.quasi_exact_match,
+        Metrics.prefix_exact_match,
+        Metrics.prefix_quasi_exact_match,
+        Metrics.perfect_exact_match,
+    ],
+    stop_sequence=["</s>", "Q=", "\n\n"],
+    trust_dataset=True,
+    version=0,
+)
+bbh_word_sorting_community = LightevalTaskConfig(
+    name="bbh-fr:tri_de_mots",
+    suite=["community"],
+    prompt_function=prompt.bbh_word_sorting,
+    hf_repo="le-leadboard/bbh-fr",
+    hf_subset="tri_de_mots",
+    hf_avail_splits=["test"],
+    evaluation_splits=["test"],
+    few_shots_split="train",
+    few_shots_select="random",
+    generation_size=20,
+    metric=[
+        Metrics.exact_match,
+        Metrics.quasi_exact_match,
+        Metrics.prefix_exact_match,
+        Metrics.prefix_quasi_exact_match,
+        Metrics.perfect_exact_match,
+    ],
+    stop_sequence=["</s>", "Q=", "\n\n"],
+    trust_dataset=True,
+    version=0,
+)
 
 # STORE YOUR EVALS
-TASKS_TABLE = [ifeval_fr_task, gpqa_fr_task]
+TASKS_TABLE = [
+    ifeval_fr_task,
+    gpqa_fr_task,
+    bbh_boolean_expressions_community,
+    bbh_causal_judgment_community,
+    bbh_date_understanding_community,
+    bbh_disambiguation_qa_community,
+    bbh_dyck_languages_community,
+    bbh_formal_fallacies_community,
+    bbh_geometric_shapes_community,
+    bbh_hyperbaton_community,
+    bbh_logical_deduction_five_objects_community,
+    bbh_logical_deduction_seven_objects_community,
+    bbh_logical_deduction_three_objects_community,
+    bbh_movie_recommendation_community,
+    bbh_multistep_arithmetic_two_community,
+    bbh_navigate_community,
+    bbh_object_counting_community,
+    bbh_penguins_in_a_table_community,
+    bbh_reasoning_about_colored_objects_community,
+    bbh_ruin_names_community,
+    bbh_salient_translation_error_detection_community,
+    bbh_snarks_community,
+    bbh_sports_understanding_community,
+    bbh_temporal_sequences_community,
+    bbh_tracking_shuffled_objects_five_objects_community,
+    bbh_tracking_shuffled_objects_seven_objects_community,
+    bbh_tracking_shuffled_objects_three_objects_community,
+    bbh_web_of_lies_community,
+    bbh_word_sorting_community,
+]

--- a/src/eval/metrics.py
+++ b/src/eval/metrics.py
@@ -22,7 +22,10 @@ from lighteval.metrics.utils.metric_utils import (
     SampleLevelMetric,
 )
 import numpy as np
-
+from lighteval.tasks.requests import SamplingMethod
+from lighteval.metrics.dynamic_metrics import (
+    IndicesExtractionConfig,
+)
 
 # Metric for math-hard-fr task
 math_pass_fr_at_1_1n = SampleLevelMetric(
@@ -63,3 +66,21 @@ math_pass_fr_at_1_1n = SampleLevelMetric(
     corpus_level_fn=np.mean,
     higher_is_better=True,
 )
+
+# Metric for GPQA-Diamond-fr task
+gpqa_instruct_pass_fr_at_1_1n = SampleLevelMetric(
+        metric_name="gpqa_pass_fr@1:1_samples",
+        sample_level_fn=PassAtK(
+            k=1,
+            n=1,
+            sample_scoring_function=lambda doc, model_response: multilingual_extractive_match_metric(
+                language=Language.FRENCH,
+                gold_extraction_target=[IndicesExtractionConfig(prefix_for_extraction="NativeLetters")],
+                pred_extraction_target=[IndicesExtractionConfig(prefix_for_extraction="NativeLetters")],
+                precision=6,
+            ).sample_level_fn(doc, model_response),
+        ).compute,
+        category=SamplingMethod.GENERATIVE,
+        corpus_level_fn=np.mean,
+        higher_is_better=True,
+    )

--- a/src/eval/metrics.py
+++ b/src/eval/metrics.py
@@ -1,30 +1,21 @@
-from lighteval.metrics.dynamic_metrics import (
-    ExprExtractionConfig,
-    LatexExtractionConfig,
-)
 from lighteval.metrics.metrics_sample import (
     PassAtK,
 )
 from lighteval.utils.language import Language
-from lighteval.metrics.utils.metric_utils import (
-    SampleLevelMetric,
-)
-from lighteval.metrics.dynamic_metrics import (
-    ExprExtractionConfig,
-    LatexExtractionConfig,
-    compare_gold_target,
-    extract_target_from_pred,
-    get_extraction_regexes,
-)
 from lighteval.metrics.utils.metric_utils import (
     MetricCategory,
     MetricUseCase,
     SampleLevelMetric,
 )
 import numpy as np
-from lighteval.tasks.requests import SamplingMethod
 from lighteval.metrics.dynamic_metrics import (
+    ExprExtractionConfig,
     IndicesExtractionConfig,
+    LatexExtractionConfig,
+    compare_gold_target,
+    extract_target_from_pred,
+    get_extraction_regexes,
+    multilingual_extractive_match_metric,
 )
 
 # Metric for math-hard-fr task
@@ -69,18 +60,25 @@ math_pass_fr_at_1_1n = SampleLevelMetric(
 
 # Metric for GPQA-Diamond-fr task
 gpqa_instruct_pass_fr_at_1_1n = SampleLevelMetric(
-        metric_name="gpqa_pass_fr@1:1_samples",
-        sample_level_fn=PassAtK(
-            k=1,
-            n=1,
-            sample_scoring_function=lambda doc, model_response: multilingual_extractive_match_metric(
-                language=Language.FRENCH,
-                gold_extraction_target=[IndicesExtractionConfig(prefix_for_extraction="NativeLetters")],
-                pred_extraction_target=[IndicesExtractionConfig(prefix_for_extraction="NativeLetters")],
-                precision=6,
-            ).sample_level_fn(doc, model_response),
-        ).compute,
-        category=SamplingMethod.GENERATIVE,
-        corpus_level_fn=np.mean,
-        higher_is_better=True,
-    )
+    metric_name="gpqa_pass_fr@1:1_samples",
+    sample_level_fn=PassAtK(
+        k=1,
+        n=1,
+        sample_scoring_function=lambda pred, ref, doc: multilingual_extractive_match_metric(
+            language=Language.FRENCH,
+            gold_extraction_target=[
+                IndicesExtractionConfig(prefix_for_extraction="NativeLetters")
+            ],
+            pred_extraction_target=[
+                IndicesExtractionConfig(prefix_for_extraction="NativeLetters")
+            ],
+            precision=6,
+        ).sample_level_fn(
+            [ref], [pred], doc
+        ),
+    ).compute,
+    category=MetricCategory.GENERATIVE_SAMPLING,
+    use_case=MetricUseCase.REASONING,
+    corpus_level_fn=np.mean,
+    higher_is_better=True,
+)

--- a/src/eval/metrics.py
+++ b/src/eval/metrics.py
@@ -1,0 +1,65 @@
+from lighteval.metrics.dynamic_metrics import (
+    ExprExtractionConfig,
+    LatexExtractionConfig,
+)
+from lighteval.metrics.metrics_sample import (
+    PassAtK,
+)
+from lighteval.utils.language import Language
+from lighteval.metrics.utils.metric_utils import (
+    SampleLevelMetric,
+)
+from lighteval.metrics.dynamic_metrics import (
+    ExprExtractionConfig,
+    LatexExtractionConfig,
+    compare_gold_target,
+    extract_target_from_pred,
+    get_extraction_regexes,
+)
+from lighteval.metrics.utils.metric_utils import (
+    MetricCategory,
+    MetricUseCase,
+    SampleLevelMetric,
+)
+import numpy as np
+
+
+# Metric for math-hard-fr task
+math_pass_fr_at_1_1n = SampleLevelMetric(
+    metric_name="math_pass_fr@1:1_samples",
+    sample_level_fn=PassAtK(
+        k=1,
+        n=1,
+        strip_strings=True,
+        # Extracting mathematical expressions and latex expressions
+        normalize_gold=lambda k: extract_target_from_pred(
+            k,
+            get_extraction_regexes(
+                formatted_doc=None,
+                target_types=[
+                    ExprExtractionConfig(),
+                    LatexExtractionConfig(boxed_match_priority=0),
+                ],
+                language=Language.FRENCH,
+            ),
+        ),
+        # Extracting mathematical expressions and latex expressions
+        normalize_pred=lambda k: extract_target_from_pred(
+            k,
+            get_extraction_regexes(
+                formatted_doc=None,
+                target_types=[
+                    ExprExtractionConfig(),
+                    LatexExtractionConfig(boxed_match_priority=0),
+                ],
+                language=Language.FRENCH,
+            ),
+        ),
+        # Uses sympy for comparison
+        sample_scoring_function=compare_gold_target,
+    ).compute,
+    category=MetricCategory.GENERATIVE_SAMPLING,
+    use_case=MetricUseCase.REASONING,
+    corpus_level_fn=np.mean,
+    higher_is_better=True,
+)

--- a/src/eval/model_params.py
+++ b/src/eval/model_params.py
@@ -1,0 +1,43 @@
+from lighteval.models.utils import GenerationParameters
+
+MODEL_PARAMS = {
+    "Qwen/Qwen3-0.6B": GenerationParameters(  # Non-thinking mode
+        temperature=0.7,
+        top_p=0.8,
+        top_k=20,
+        min_p=0.0,
+    ),
+    "Qwen/Qwen3-1.7B": GenerationParameters(  # Non-thinking mode
+        temperature=0.7,
+        top_p=0.8,
+        top_k=20,
+        min_p=0.0,
+    ),
+    "Qwen/Qwen2.5-0.5B-Instruct": GenerationParameters(
+        temperature=0.7,
+        top_p=0.8,
+        top_k=20,
+        repetition_penalty=1,
+        presence_penalty=0,
+        frequency_penalty=0,
+    ),
+    "Qwen/Qwen2.5-1.5B-Instruct": GenerationParameters(
+        temperature=0.7,
+        top_p=0.8,
+        top_k=20,
+        repetition_penalty=1,
+        presence_penalty=0,
+        frequency_penalty=0,
+    ),
+    "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B": GenerationParameters(
+        temperature=0.6,
+        top_p=0.95,
+        top_k=20,
+    ),
+    "LiquidAI/LFM2-1.2B": GenerationParameters(
+        temperature=0.3, min_p=0.15, repetition_penalty=1.05
+    ),
+    "LiquidAI/LFM2-700M": GenerationParameters(
+        temperature=0.3, min_p=0.15, repetition_penalty=1.05
+    ),
+}

--- a/src/eval/prompts.py
+++ b/src/eval/prompts.py
@@ -1,0 +1,234 @@
+import random
+from lighteval.tasks.default_prompts import LETTER_INDICES
+from lighteval.tasks.requests import Doc
+
+
+# Ifeval-fr prompt function
+def prompt_ifeval_fr(line, task_name: str = None):
+    return Doc(
+        task_name=task_name,
+        query=line["prompt"],
+        choices=[""],
+        gold_index=0,
+        instruction="",
+        specific={
+            "instructions_id_list": line["instruction_id_list"],
+            "kwargs": line["kwargs"],
+        },
+    )
+
+
+# gpqa-fr prompt function
+def prompt_gpqa_fr(line, task_name: str = None):
+    gold_index = random.randint(0, 3)
+    choices = [
+        line["Réponse incorrecte 1"],
+        line["Réponse incorrecte 2"],
+        line["Réponse incorrecte 3"],
+    ]
+    choices.insert(gold_index, line["Réponse correcte"])
+
+    instruction = "Choisissez la réponse correcte aux questions suivantes.\n\n"
+
+    query = f"Question: {line['Question']}\n"
+    query += "".join(
+        [f"{key}. {choice}\n" for key, choice in zip(LETTER_INDICES, choices)]
+    )
+    query += "Réponse: "
+    return Doc(
+        task_name=task_name,
+        query=f"{instruction}{query}",
+        choices=LETTER_INDICES[: len(choices)],
+        gold_index=gold_index,
+        instruction=instruction,
+    )
+
+
+# bbh-fr prompt functions
+def bbh(line, instruction, choices, task_name: str = None):
+    return Doc(
+        task_name=task_name,
+        query=f"{instruction}Q: {line['input']}\nA:",
+        choices=choices,
+        gold_index=choices.index(line["target"]),
+        instruction=instruction,
+    )
+
+
+def bbh_boolean_expressions(line, task_name: str = None):
+    instruction = "Évalue le résultat d'une expression booléenne aléatoire.\n\n"
+    choices = ["Incorrect", "Vrai"]
+    return bbh(line, instruction, choices, task_name)
+
+
+def bbh_causal_judgment(line, task_name: str = None):
+    instruction = "Réponds à des questions sur l’attribution causale.\n\n"
+    choices = ["Oui", "Non"]
+    return bbh(line, instruction, choices, task_name)
+
+
+def bbh_date_understanding(line, task_name: str = None):
+    instruction = "Infère la date à partir du contexte.\n\n"
+    choices = [f"({c})" for c in LETTER_INDICES[:6]]
+    return bbh(line, instruction, choices, task_name)
+
+
+def bbh_disambiguation_qa(line, task_name: str = None):
+    instruction = "Clarifie le sens des phrases avec des pronoms ambigus.\n\n"
+    choices = [f"({c})" for c in LETTER_INDICES[:3]]
+    return bbh(line, instruction, choices, task_name)
+
+
+def bbh_dyck_languages(line, task_name: str = None):  # Can only be done in generative
+    instruction = "Ferme correctement un mot Dyck-n.\n\n"
+    choices = [line["target"]]
+    return bbh(line, instruction, choices, task_name)
+
+
+def bbh_formal_fallacies(line, task_name: str = None):
+    instruction = (
+        "Distingue les arguments déductivement valides des sophismes formels.\n\n"
+    )
+    choices = ["valide", "invalidee"]
+    return bbh(line, instruction, choices, task_name)
+
+
+def bbh_geometric_shapes(line, task_name: str = None):
+    instruction = "Nomme les formes géométriques à partir de leurs chemins SVG.\n\n"
+    choices = [f"({c})" for c in LETTER_INDICES[:11]]
+    return bbh(line, instruction, choices, task_name)
+
+
+def bbh_hyperbaton(line, task_name: str = None):
+    instruction = "Ordonne correctement les adjectifs dans des phrases anglaises.\n\n"
+    choices = [f"({c})" for c in LETTER_INDICES[:2]]
+    return bbh(line, instruction, choices, task_name)
+
+
+def bbh_logical_deduction_five_objects(line, task_name: str = None):
+    instruction = "Une tâche de déduction logique qui nécessite de déduire l’ordre d’une séquence d’objets.\n\n"
+    choices = [f"({c})" for c in LETTER_INDICES[:5]]
+    return bbh(line, instruction, choices, task_name)
+
+
+def bbh_logical_deduction_seven_objects(line, task_name: str = None):
+    instruction = "Une tâche de déduction logique qui nécessite de déduire l’ordre d’une séquence d’objets.\n\n"
+    choices = [f"({c})" for c in LETTER_INDICES[:7]]
+    return bbh(line, instruction, choices, task_name)
+
+
+def bbh_logical_deduction_three_objects(line, task_name: str = None):
+    instruction = "Une tâche de déduction logique qui nécessite de déduire l’ordre d’une séquence d’objets.\n\n"
+    choices = [f"({c})" for c in LETTER_INDICES[:3]]
+    return bbh(line, instruction, choices, task_name)
+
+
+def bbh_movie_recommendation(line, task_name: str = None):
+    if line["target"] == "Monsters, Inc":  # this line is not correctly formatted
+        print(
+            "One sample removed from task bbh:movie_recommendation because its line is incorrectly formatted."
+        )
+        return []
+    instruction = "Recommande des films similaires à la liste de films donnée.\n\n"
+    choices = [f"({c})" for c in LETTER_INDICES[:6]]
+    return bbh(line, instruction, choices, task_name)
+
+
+def bbh_multistep_arithmetic_two(line, task_name: str = None):
+    instruction = "Résous des problèmes arithmétiques à étapes multiples.\n\n"  # Can only be done in generative
+    choices = [line["target"]]
+    return bbh(line, instruction, choices, task_name)
+
+
+def bbh_navigate(line, task_name: str = None):
+    instruction = "Étant donné une série d’instructions de navigation, détermine si l’on revient au point de départ.\n\n"
+    choices = ["Oui", "Non"]
+    return bbh(line, instruction, choices, task_name)
+
+
+def bbh_object_counting(line, task_name: str = None):
+    instruction = "Questions impliquant de dénombrer des objets et demander au modèle de les compter.\n\n"
+    choices = [str(i) for i in range(1, 19)]
+    return bbh(line, instruction, choices, task_name)
+
+
+def bbh_penguins_in_a_table(line, task_name: str = None):
+    instruction = (
+        "Réponds à des questions sur un tableau de pingouins et leurs attributs.\n\n"
+    )
+    choices = [f"({c})" for c in LETTER_INDICES[:5]]
+    return bbh(line, instruction, choices, task_name)
+
+
+def bbh_reasoning_about_colored_objects(line, task_name: str = None):
+    instruction = "Réponds à des questions très simples sur les couleurs des objets sur une surface.\n\n"
+    choices = [f"({c})" for c in LETTER_INDICES[:18]]
+    return bbh(line, instruction, choices, task_name)
+
+
+def bbh_ruin_names(line, task_name: str = None):
+    if line["target"] in [
+        "dearth, wind, & fire",
+        "rita, sue and bob poo",
+    ]:  # line not correctly formatted
+        print(
+            "One sample removed from task bbh:ruin_names because its line is incorrectly formatted."
+        )
+        return []
+    instruction = "Choisis la modification humoristique qui « ruine » le nom du film ou de l’artiste musical donné.\n\n"
+    choices = [f"({c})" for c in LETTER_INDICES[:6]]
+    return bbh(line, instruction, choices, task_name)
+
+
+def bbh_salient_translation_error_detection(line, task_name: str = None):
+    instruction = "Détecte le type d’erreur dans une traduction anglaise d’une phrase source allemande.\n\n"
+    choices = [f"({c})" for c in LETTER_INDICES[:6]]
+    return bbh(line, instruction, choices, task_name)
+
+
+def bbh_snarks(line, task_name: str = None):
+    instruction = "Détermine laquelle des deux phrases est sarcastique. Selon le dictionnaire de l’université de Cambridge, le sarcasme est « l’utilisation de remarques qui signifient clairement le contraire de ce qu’elles disent, faites pour blesser quelqu’un ou critiquer quelque chose de manière humoristique ». Les phrases sarcastiques contiennent souvent des propos satiriques ou ironiques, des hyperboles, des remarques ambivalentes ou spirituelles.\n\n"
+    choices = [f"({c})" for c in LETTER_INDICES[:2]]
+    return bbh(line, instruction, choices, task_name)
+
+
+def bbh_sports_understanding(line, task_name: str = None):
+    instruction = "Détermine si une phrase artificiellement construite liée au sport est plausible ou non.\n\n"
+    choices = ["Oui", "Non"]
+    return bbh(line, instruction, choices, task_name)
+
+
+def bbh_temporal_sequences(line, task_name: str = None):
+    instruction = "Description de tâche: Réponds à des questions sur les moments auxquels certains événements ont pu se produire.\n\n"
+    choices = [f"({c})" for c in LETTER_INDICES[:4]]
+    return bbh(line, instruction, choices, task_name)
+
+
+def bbh_tracking_shuffled_objects_five_objects(line, task_name: str = None):
+    instruction = "Détermine les positions finales d’un ensemble d’objets données leurs positions initiales et la description d’une séquence d’échanges.\n\n"
+    choices = [f"({c})" for c in LETTER_INDICES[:5]]
+    return bbh(line, instruction, choices, task_name)
+
+
+def bbh_tracking_shuffled_objects_seven_objects(line, task_name: str = None):
+    instruction = "Détermine les positions finales d’un ensemble d’objets données leurs positions initiales et la description d’une séquence d’échanges.\n\n"
+    choices = [f"({c})" for c in LETTER_INDICES[:7]]
+    return bbh(line, instruction, choices, task_name)
+
+
+def bbh_tracking_shuffled_objects_three_objects(line, task_name: str = None):
+    instruction = "Détermine les positions finales d’un ensemble d’objets données leurs positions initiales et la description d’une séquence d’échanges.\n\n"
+    choices = [f"({c})" for c in LETTER_INDICES[:3]]
+    return bbh(line, instruction, choices, task_name)
+
+
+def bbh_web_of_lies(line, task_name: str = None):
+    instruction = "Évalue une fonction booléenne aléatoire exprimée sous forme de problème en mots.\n\n"
+    choices = ["Oui", "Non"]
+    return bbh(line, instruction, choices, task_name)
+
+
+def bbh_word_sorting(line, task_name: str = None):
+    instruction = "Trie une liste de mots.\n\n"  # Can only be done in generative
+    choices = [line["target"]]
+    return bbh(line, instruction, choices, task_name)

--- a/src/eval/prompts.py
+++ b/src/eval/prompts.py
@@ -232,3 +232,58 @@ def bbh_word_sorting(line, task_name: str = None):
     instruction = "Trie une liste de mots.\n\n"  # Can only be done in generative
     choices = [line["target"]]
     return bbh(line, instruction, choices, task_name)
+
+
+NL_PROMPT = """Problème:
+Déterminer le domaine de l'expression $\frac{\sqrt{x-2}}{\sqrt{5-x}}$.
+
+Solution:
+Les expressions sous chaque racine carrée doivent être positives ou nulles. Ainsi, $x - 2 \ge 0$, donc $x \ge 2$, et $5 - x \ge 0$, donc $x \le 5$. De plus, le dénominateur ne peut pas être nul, donc $5 - x > 0$, ce qui donne $x < 5$. Par conséquent, le domaine de l'expression est $\boxed{[2,5)}$.
+Réponse finale : La réponse finale est $[2,5)$. J'espère que c'est correct.
+
+Problème:
+Si $\det \mathbf{A} = 2$ et $\det \mathbf{B} = 12$, déterminer $\det (\mathbf{A} \mathbf{B})$.
+
+Solution:
+On a que $\det (\mathbf{A} \mathbf{B}) = (\det \mathbf{A})(\det \mathbf{B}) = (2)(12) = \boxed{24}$.
+Réponse finale : La réponse finale est $24$. J'espère que c'est correct.
+
+Problème:
+Terrell soulève habituellement deux haltères de 20 livres 12 fois. S’il utilise plutôt deux haltères de 15 livres, combien de fois doit-il les soulever pour soulever le même poids total ?
+
+Solution:
+Si Terrell soulève deux haltères de 20 livres 12 fois, il soulève un total de $2\cdot 12\cdot20=480$ livres. S’il soulève plutôt deux haltères de 15 livres $n$ fois, il soulèvera un total de $2\cdot15\cdot n=30n$ livres. En égalant cela à 480 livres, on peut résoudre pour $n$ :
+\begin{align*}
+30n&=480\\
+\Rightarrow\qquad n&=480/30=\boxed{16}
+\end{align*}
+Réponse finale : La réponse finale est $16$. J'espère que c'est correct.
+
+Problème:
+Si le système d’équations suivant
+
+\begin{align*}
+6x-4y&=a,\\
+6y-9x &=b.
+\end{align*}admet une solution $(x, y)$ avec $x$ et $y$ tous deux non nuls,
+déterminer $\frac{a}{b}$, en supposant que $b$ est non nul.
+
+Solution:
+Si on multiplie la première équation par $-\frac{3}{2}$, on obtient
+
+$$6y - 9x = -\frac{3}{2}a.$$Or on sait aussi que $6y - 9x = b$, donc
+
+$$-\frac{3}{2}a = b \Rightarrow \frac{a}{b} = \boxed{-\frac{2}{3}}.$$
+Réponse finale : La réponse finale est $-\frac{2}{3}$. J'espère que c'est correct."""
+
+
+def prompt_math_hard_fr(line, task_name: str = None):
+    """
+    Prompt function for the Math-Hard-fr task. With few-shot examples.
+    """
+    return Doc(
+        task_name=task_name,
+        query=f"{NL_PROMPT}\n\nProblem:\n{line['problem']}\n\nSolution:",
+        choices=[line["solution"]],
+        gold_index=0,
+    )

--- a/src/eval/prompts.py
+++ b/src/eval/prompts.py
@@ -234,6 +234,7 @@ def bbh_word_sorting(line, task_name: str = None):
     return bbh(line, instruction, choices, task_name)
 
 
+# math-hard-fr prompt function
 NL_PROMPT = """Problème:
 Déterminer le domaine de l'expression $\frac{\sqrt{x-2}}{\sqrt{5-x}}$.
 

--- a/src/eval/prompts.py
+++ b/src/eval/prompts.py
@@ -22,18 +22,25 @@ def prompt_ifeval_fr(line, task_name: str = None):
 def gpqa_diamond_fr_instruct(line, task_name: str = None):
     """Prompt template adapted from simple-evals: https://github.com/openai/simple-evals/blob/83ed7640a7d9cd26849bcb3340125002ef14abbe/common.py#L14"""
     gold_index = random.randint(0, 3)
-    choices = [line["Incorrect Answer 1"], line["Incorrect Answer 2"], line["Incorrect Answer 3"]]
+    choices = [
+        line["Incorrect Answer 1"],
+        line["Incorrect Answer 2"],
+        line["Incorrect Answer 3"],
+    ]
     choices.insert(gold_index, line["Correct Answer"])
-    instruction = "Answer the following multiple choice question. The last line of your response should be of the following format: 'Answer: $LETTER' (without quotes) where LETTER is one of ABCD. Think step by step before answering."
-    query_template = "{Instruction}\n\n{Question}\n\nA) {A}\nB) {B}\nC) {C}\nD) {D}"
+    query_template = (
+        "Répondez à la question à choix multiple suivante. "
+        "La dernière ligne de votre réponse doit avoir le format suivant : 'Réponse : $LETTRE' "
+        "(sans les guillemets) où LETTRE est l'une de A, B, C ou D. "
+        "Réfléchissez étape par étape avant de répondre.\n\n"
+        "{Question}\n\n"
+        "A) {A}\n"
+        "B) {B}\n"
+        "C) {C}\n"
+        "D) {D}"
+    )
     query = query_template.format(
-        # Stripping to avoid accidental extra whitespaces, present in GPQA
-        A=choices[0].strip(),
-        B=choices[1].strip(),
-        C=choices[2].strip(),
-        D=choices[3].strip(),
-        Question=line["problem"].strip(),
-        Instruction=instruction,
+        A=choices[0], B=choices[1], C=choices[2], D=choices[3], Question=line["problem"]
     )
 
     return Doc(
@@ -41,7 +48,7 @@ def gpqa_diamond_fr_instruct(line, task_name: str = None):
         query=query,
         choices=LETTER_INDICES[: len(choices)],
         gold_index=gold_index,
-        instruction=instruction,
+        instruction=query,
     )
 
 

--- a/src/eval/prompts.py
+++ b/src/eval/prompts.py
@@ -44,6 +44,19 @@ def prompt_gpqa_fr(line, task_name: str = None):
     )
 
 
+# boolq-fr prompt function
+def prompt_boolq_fr(line, task_name: str = None):
+    question = (
+        line["question"][:-1] if line["question"][-2:] == "?" else line["question"]
+    )
+    return Doc(
+        task_name=task_name,
+        query=f"Passage: {line['passage']}\nQuestion: {question}\nAnswer:",
+        choices=["Non", "Oui"],
+        gold_index=int(line["label"]),
+    )
+
+
 # bbh-fr prompt functions
 def bbh(line, instruction, choices, task_name: str = None):
     return Doc(

--- a/src/eval/prompts.py
+++ b/src/eval/prompts.py
@@ -247,6 +247,23 @@ def bbh_word_sorting(line, task_name: str = None):
     return bbh(line, instruction, choices, task_name)
 
 
+# musr-fr prompt function
+def musr_fr(line, task_name: str = None):
+    choices = line["choices"]
+    query = line["narrative"] + "\n\n"
+    query += line["question"] + "\n\n"
+    for i, choice in enumerate(choices):
+        query += f"{i + 1} - {choice}\n"
+    query += "Answer:"
+
+    return Doc(
+        task_name=task_name,
+        query=query,
+        choices=choices,
+        gold_index=line["answer_index"],
+    )
+
+
 # math-hard-fr prompt function
 NL_PROMPT = """Problème:
 Déterminer le domaine de l'expression $\frac{\sqrt{x-2}}{\sqrt{5-x}}$.

--- a/src/eval/tasks.py
+++ b/src/eval/tasks.py
@@ -33,37 +33,14 @@ See : https://huggingface.co/fr-gouv-coordination-ia
 from lighteval.metrics.metrics import Metrics
 from lighteval.tasks.extended.ifeval.main import ifeval_metrics
 from lighteval.tasks.lighteval_task import LightevalTaskConfig
-import prompts as prompt
-from lighteval.metrics.dynamic_metrics import (
-    ExprExtractionConfig,
-    LatexExtractionConfig,
-)
-from lighteval.metrics.metrics_sample import (
-    PassAtK,
-)
-from lighteval.utils.language import Language
-from lighteval.metrics.utils.metric_utils import (
-    SampleLevelMetric,
-)
-from lighteval.metrics.dynamic_metrics import (
-    ExprExtractionConfig,
-    LatexExtractionConfig,
-    compare_gold_target,
-    extract_target_from_pred,
-    get_extraction_regexes,
-)
-from lighteval.metrics.utils.metric_utils import (
-    MetricCategory,
-    MetricUseCase,
-    SampleLevelMetric,
-)
-import numpy as np
+import prompts as custom_prompt
+import metrics as custom_metric
 
 
 # IFEVal-fr task
 ifeval_fr_task = LightevalTaskConfig(
     name="ifeval-fr",
-    prompt_function=prompt.prompt_ifeval_fr,
+    prompt_function=custom_prompt.prompt_ifeval_fr,
     suite=["community"],
     hf_repo="jzhang86/fr_ifeval",
     hf_subset="default",
@@ -81,7 +58,7 @@ ifeval_fr_task = LightevalTaskConfig(
 gpqa_fr_task = LightevalTaskConfig(
     name="gpqa-fr",
     suite=["community"],
-    prompt_function=prompt.prompt_gpqa_fr,
+    prompt_function=custom_prompt.prompt_gpqa_fr,
     hf_repo="le-leadboard/gpqa-fr",
     hf_subset="default",
     hf_avail_splits=["train"],
@@ -97,49 +74,10 @@ gpqa_fr_task = LightevalTaskConfig(
 
 
 # Math-Hard-fr task
-math_pass_fr_at_1_1n = SampleLevelMetric(
-    metric_name="math_pass_fr@1:1_samples",
-    sample_level_fn=PassAtK(
-        k=1,
-        n=1,
-        strip_strings=True,
-        # Extracting mathematical expressions and latex expressions
-        normalize_gold=lambda k: extract_target_from_pred(
-            k,
-            get_extraction_regexes(
-                formatted_doc=None,
-                target_types=[
-                    ExprExtractionConfig(),
-                    LatexExtractionConfig(boxed_match_priority=0),
-                ],
-                language=Language.FRENCH,
-            ),
-        ),
-        # Extracting mathematical expressions and latex expressions
-        normalize_pred=lambda k: extract_target_from_pred(
-            k,
-            get_extraction_regexes(
-                formatted_doc=None,
-                target_types=[
-                    ExprExtractionConfig(),
-                    LatexExtractionConfig(boxed_match_priority=0),
-                ],
-                language=Language.FRENCH,
-            ),
-        ),
-        # Uses sympy for comparison
-        sample_scoring_function=compare_gold_target,
-    ).compute,
-    category=MetricCategory.GENERATIVE_SAMPLING,
-    use_case=MetricUseCase.REASONING,
-    corpus_level_fn=np.mean,
-    higher_is_better=True,
-)
-
 math_hard_fr_task = LightevalTaskConfig(
     name="math-hard-fr",
     suite=["community"],
-    prompt_function=prompt.prompt_math_hard_fr,
+    prompt_function=custom_prompt.prompt_math_hard_fr,
     hf_repo="le-leadboard/MATH_LVL5_fr",
     hf_subset="default",
     hf_avail_splits=["test"],
@@ -148,7 +86,7 @@ math_hard_fr_task = LightevalTaskConfig(
     few_shots_select="random",
     generation_size=4096,
     metric=[
-        math_pass_fr_at_1_1n,
+        custom_metric.math_pass_fr_at_1_1n,
     ],
     trust_dataset=True,
     version=0,
@@ -158,7 +96,7 @@ math_hard_fr_task = LightevalTaskConfig(
 bbh_boolean_expressions_community = LightevalTaskConfig(
     name="bbh-fr:expressions_booléennes",
     suite=["community"],
-    prompt_function=prompt.bbh_boolean_expressions,
+    prompt_function=custom_prompt.bbh_boolean_expressions,
     hf_repo="le-leadboard/bbh-fr",
     hf_subset="expressions_booléennes",
     hf_avail_splits=["test"],
@@ -180,7 +118,7 @@ bbh_boolean_expressions_community = LightevalTaskConfig(
 bbh_causal_judgment_community = LightevalTaskConfig(
     name="bbh-fr:jugement_causal",
     suite=["community"],
-    prompt_function=prompt.bbh_causal_judgment,
+    prompt_function=custom_prompt.bbh_causal_judgment,
     hf_repo="le-leadboard/bbh-fr",
     hf_subset="jugement_causal",
     hf_avail_splits=["test"],
@@ -202,7 +140,7 @@ bbh_causal_judgment_community = LightevalTaskConfig(
 bbh_date_understanding_community = LightevalTaskConfig(
     name="bbh-fr:compréhension_de_la_date",
     suite=["community"],
-    prompt_function=prompt.bbh_date_understanding,
+    prompt_function=custom_prompt.bbh_date_understanding,
     hf_repo="le-leadboard/bbh-fr",
     hf_subset="compréhension_de_la_date",
     hf_avail_splits=["test"],
@@ -224,7 +162,7 @@ bbh_date_understanding_community = LightevalTaskConfig(
 bbh_disambiguation_qa_community = LightevalTaskConfig(
     name="bbh-fr:désambiguïsation_qa",
     suite=["community"],
-    prompt_function=prompt.bbh_disambiguation_qa,
+    prompt_function=custom_prompt.bbh_disambiguation_qa,
     hf_repo="le-leadboard/bbh-fr",
     hf_subset="désambiguïsation_qa",
     hf_avail_splits=["test"],
@@ -246,7 +184,7 @@ bbh_disambiguation_qa_community = LightevalTaskConfig(
 bbh_dyck_languages_community = LightevalTaskConfig(
     name="bbh-fr:dyck_languages",
     suite=["community"],
-    prompt_function=prompt.bbh_dyck_languages,
+    prompt_function=custom_prompt.bbh_dyck_languages,
     hf_repo="le-leadboard/bbh-fr",
     hf_subset="dyck_languages",
     hf_avail_splits=["test"],
@@ -268,7 +206,7 @@ bbh_dyck_languages_community = LightevalTaskConfig(
 bbh_formal_fallacies_community = LightevalTaskConfig(
     name="bbh-fr:sophismes_formels",
     suite=["community"],
-    prompt_function=prompt.bbh_formal_fallacies,
+    prompt_function=custom_prompt.bbh_formal_fallacies,
     hf_repo="le-leadboard/bbh-fr",
     hf_subset="sophismes_formels",
     hf_avail_splits=["test"],
@@ -290,7 +228,7 @@ bbh_formal_fallacies_community = LightevalTaskConfig(
 bbh_geometric_shapes_community = LightevalTaskConfig(
     name="bbh-fr:formes_géométriques",
     suite=["community"],
-    prompt_function=prompt.bbh_geometric_shapes,
+    prompt_function=custom_prompt.bbh_geometric_shapes,
     hf_repo="le-leadboard/bbh-fr",
     hf_subset="formes_géométriques",
     hf_avail_splits=["test"],
@@ -312,7 +250,7 @@ bbh_geometric_shapes_community = LightevalTaskConfig(
 bbh_hyperbaton_community = LightevalTaskConfig(
     name="bbh-fr:hyperbate",
     suite=["community"],
-    prompt_function=prompt.bbh_hyperbaton,
+    prompt_function=custom_prompt.bbh_hyperbaton,
     hf_repo="le-leadboard/bbh-fr",
     hf_subset="hyperbate",
     hf_avail_splits=["test"],
@@ -334,7 +272,7 @@ bbh_hyperbaton_community = LightevalTaskConfig(
 bbh_logical_deduction_five_objects_community = LightevalTaskConfig(
     name="bbh-fr:suivi_objets_mélangés_cinq_objets",
     suite=["community"],
-    prompt_function=prompt.bbh_logical_deduction_five_objects,
+    prompt_function=custom_prompt.bbh_logical_deduction_five_objects,
     hf_repo="le-leadboard/bbh-fr",
     hf_subset="suivi_objets_mélangés_cinq_objets",
     hf_avail_splits=["test"],
@@ -356,7 +294,7 @@ bbh_logical_deduction_five_objects_community = LightevalTaskConfig(
 bbh_logical_deduction_seven_objects_community = LightevalTaskConfig(
     name="bbh-fr:déduction_logique_sept_objets",
     suite=["community"],
-    prompt_function=prompt.bbh_logical_deduction_seven_objects,
+    prompt_function=custom_prompt.bbh_logical_deduction_seven_objects,
     hf_repo="le-leadboard/bbh-fr",
     hf_subset="déduction_logique_sept_objets",
     hf_avail_splits=["test"],
@@ -378,7 +316,7 @@ bbh_logical_deduction_seven_objects_community = LightevalTaskConfig(
 bbh_logical_deduction_three_objects_community = LightevalTaskConfig(
     name="bbh-fr:déduction_logique_trois_objets",
     suite=["community"],
-    prompt_function=prompt.bbh_logical_deduction_three_objects,
+    prompt_function=custom_prompt.bbh_logical_deduction_three_objects,
     hf_repo="le-leadboard/bbh-fr",
     hf_subset="déduction_logique_trois_objets",
     hf_avail_splits=["test"],
@@ -400,7 +338,7 @@ bbh_logical_deduction_three_objects_community = LightevalTaskConfig(
 bbh_movie_recommendation_community = LightevalTaskConfig(
     name="bbh-fr:recommandation_de_film",
     suite=["community"],
-    prompt_function=prompt.bbh_movie_recommendation,
+    prompt_function=custom_prompt.bbh_movie_recommendation,
     hf_repo="le-leadboard/bbh-fr",
     hf_subset="recommandation_de_film",
     hf_avail_splits=["test"],
@@ -422,7 +360,7 @@ bbh_movie_recommendation_community = LightevalTaskConfig(
 bbh_multistep_arithmetic_two_community = LightevalTaskConfig(
     name="bbh-fr:multistep_arithmetic_two",
     suite=["community"],
-    prompt_function=prompt.bbh_multistep_arithmetic_two,
+    prompt_function=custom_prompt.bbh_multistep_arithmetic_two,
     hf_repo="le-leadboard/bbh-fr",
     hf_subset="multistep_arithmetic_two",
     hf_avail_splits=["test"],
@@ -444,7 +382,7 @@ bbh_multistep_arithmetic_two_community = LightevalTaskConfig(
 bbh_navigate_community = LightevalTaskConfig(
     name="bbh-fr:naviguer",
     suite=["community"],
-    prompt_function=prompt.bbh_navigate,
+    prompt_function=custom_prompt.bbh_navigate,
     hf_repo="le-leadboard/bbh-fr",
     hf_subset="naviguer",
     hf_avail_splits=["test"],
@@ -466,7 +404,7 @@ bbh_navigate_community = LightevalTaskConfig(
 bbh_object_counting_community = LightevalTaskConfig(
     name="bbh-fr:comptage_d_objets",
     suite=["community"],
-    prompt_function=prompt.bbh_object_counting,
+    prompt_function=custom_prompt.bbh_object_counting,
     hf_repo="le-leadboard/bbh-fr",
     hf_subset="comptage_d_objets",
     hf_avail_splits=["test"],
@@ -488,7 +426,7 @@ bbh_object_counting_community = LightevalTaskConfig(
 bbh_penguins_in_a_table_community = LightevalTaskConfig(
     name="bbh-fr:pingouins_sur_une_table",
     suite=["community"],
-    prompt_function=prompt.bbh_penguins_in_a_table,
+    prompt_function=custom_prompt.bbh_penguins_in_a_table,
     hf_repo="le-leadboard/bbh-fr",
     hf_subset="pingouins_sur_une_table",
     hf_avail_splits=["test"],
@@ -510,7 +448,7 @@ bbh_penguins_in_a_table_community = LightevalTaskConfig(
 bbh_reasoning_about_colored_objects_community = LightevalTaskConfig(
     name="bbh-fr:raisonnement_sur_les_objets_colorés",
     suite=["community"],
-    prompt_function=prompt.bbh_reasoning_about_colored_objects,
+    prompt_function=custom_prompt.bbh_reasoning_about_colored_objects,
     hf_repo="le-leadboard/bbh-fr",
     hf_subset="raisonnement_sur_les_objets_colorés",
     hf_avail_splits=["test"],
@@ -532,7 +470,7 @@ bbh_reasoning_about_colored_objects_community = LightevalTaskConfig(
 bbh_ruin_names_community = LightevalTaskConfig(
     name="bbh-fr:noms_de_ruines",
     suite=["community"],
-    prompt_function=prompt.bbh_ruin_names,
+    prompt_function=custom_prompt.bbh_ruin_names,
     hf_repo="le-leadboard/bbh-fr",
     hf_subset="noms_de_ruines",
     hf_avail_splits=["test"],
@@ -554,7 +492,7 @@ bbh_ruin_names_community = LightevalTaskConfig(
 bbh_salient_translation_error_detection_community = LightevalTaskConfig(
     name="bbh-fr:détection_d_erreur_de_traduction_sailante",
     suite=["community"],
-    prompt_function=prompt.bbh_salient_translation_error_detection,
+    prompt_function=custom_prompt.bbh_salient_translation_error_detection,
     hf_repo="le-leadboard/bbh-fr",
     hf_subset="détection_d_erreur_de_traduction_sailante",
     hf_avail_splits=["test"],
@@ -576,7 +514,7 @@ bbh_salient_translation_error_detection_community = LightevalTaskConfig(
 bbh_snarks_community = LightevalTaskConfig(
     name="bbh-fr:sarcasmes",
     suite=["community"],
-    prompt_function=prompt.bbh_snarks,
+    prompt_function=custom_prompt.bbh_snarks,
     hf_repo="le-leadboard/bbh-fr",
     hf_subset="sarcasmes",
     hf_avail_splits=["test"],
@@ -598,7 +536,7 @@ bbh_snarks_community = LightevalTaskConfig(
 bbh_sports_understanding_community = LightevalTaskConfig(
     name="bbh-fr:compréhension_des_sports",
     suite=["community"],
-    prompt_function=prompt.bbh_sports_understanding,
+    prompt_function=custom_prompt.bbh_sports_understanding,
     hf_repo="le-leadboard/bbh-fr",
     hf_subset="compréhension_des_sports",
     hf_avail_splits=["test"],
@@ -620,7 +558,7 @@ bbh_sports_understanding_community = LightevalTaskConfig(
 bbh_temporal_sequences_community = LightevalTaskConfig(
     name="bbh-fr:séquences_temporelles",
     suite=["community"],
-    prompt_function=prompt.bbh_temporal_sequences,
+    prompt_function=custom_prompt.bbh_temporal_sequences,
     hf_repo="le-leadboard/bbh-fr",
     hf_subset="séquences_temporelles",
     hf_avail_splits=["test"],
@@ -642,7 +580,7 @@ bbh_temporal_sequences_community = LightevalTaskConfig(
 bbh_tracking_shuffled_objects_five_objects_community = LightevalTaskConfig(
     name="bbh-fr:suivi_objets_mélangés_cinq_objets",
     suite=["community"],
-    prompt_function=prompt.bbh_tracking_shuffled_objects_five_objects,
+    prompt_function=custom_prompt.bbh_tracking_shuffled_objects_five_objects,
     hf_repo="le-leadboard/bbh-fr",
     hf_subset="suivi_objets_mélangés_cinq_objets",
     hf_avail_splits=["test"],
@@ -664,7 +602,7 @@ bbh_tracking_shuffled_objects_five_objects_community = LightevalTaskConfig(
 bbh_tracking_shuffled_objects_seven_objects_community = LightevalTaskConfig(
     name="bbh-fr:suivi_objets_mélangés_sept_objets",
     suite=["community"],
-    prompt_function=prompt.bbh_tracking_shuffled_objects_seven_objects,
+    prompt_function=custom_prompt.bbh_tracking_shuffled_objects_seven_objects,
     hf_repo="le-leadboard/bbh-fr",
     hf_subset="suivi_objets_mélangés_sept_objets",
     hf_avail_splits=["test"],
@@ -686,7 +624,7 @@ bbh_tracking_shuffled_objects_seven_objects_community = LightevalTaskConfig(
 bbh_tracking_shuffled_objects_three_objects_community = LightevalTaskConfig(
     name="bbh-fr:suivi_objets_mélangés_trois_objets",
     suite=["community"],
-    prompt_function=prompt.bbh_tracking_shuffled_objects_three_objects,
+    prompt_function=custom_prompt.bbh_tracking_shuffled_objects_three_objects,
     hf_repo="le-leadboard/bbh-fr",
     hf_subset="suivi_objets_mélangés_trois_objets",
     hf_avail_splits=["test"],
@@ -708,7 +646,7 @@ bbh_tracking_shuffled_objects_three_objects_community = LightevalTaskConfig(
 bbh_web_of_lies_community = LightevalTaskConfig(
     name="bbh-fr:toile_de_mensonges",
     suite=["community"],
-    prompt_function=prompt.bbh_web_of_lies,
+    prompt_function=custom_prompt.bbh_web_of_lies,
     hf_repo="le-leadboard/bbh-fr",
     hf_subset="toile_de_mensonges",
     hf_avail_splits=["test"],
@@ -730,7 +668,7 @@ bbh_web_of_lies_community = LightevalTaskConfig(
 bbh_word_sorting_community = LightevalTaskConfig(
     name="bbh-fr:tri_de_mots",
     suite=["community"],
-    prompt_function=prompt.bbh_word_sorting,
+    prompt_function=custom_prompt.bbh_word_sorting,
     hf_repo="le-leadboard/bbh-fr",
     hf_subset="tri_de_mots",
     hf_avail_splits=["test"],

--- a/src/eval/tasks.py
+++ b/src/eval/tasks.py
@@ -44,7 +44,7 @@ gpqa_diamond_fr_task = LightevalTaskConfig(
     evaluation_splits=["train"],
     few_shots_split="train",
     few_shots_select="random_sampling",
-    generation_size=32768,
+    generation_size=2048,
     metric=[
         custom_metric.gpqa_instruct_pass_fr_at_1_1n,
     ],

--- a/src/eval/tasks.py
+++ b/src/eval/tasks.py
@@ -34,6 +34,30 @@ from lighteval.metrics.metrics import Metrics
 from lighteval.tasks.extended.ifeval.main import ifeval_metrics
 from lighteval.tasks.lighteval_task import LightevalTaskConfig
 import prompts as prompt
+from lighteval.metrics.dynamic_metrics import (
+    ExprExtractionConfig,
+    LatexExtractionConfig,
+)
+from lighteval.metrics.metrics_sample import (
+    PassAtK,
+)
+from lighteval.utils.language import Language
+from lighteval.metrics.utils.metric_utils import (
+    SampleLevelMetric,
+)
+from lighteval.metrics.dynamic_metrics import (
+    ExprExtractionConfig,
+    LatexExtractionConfig,
+    compare_gold_target,
+    extract_target_from_pred,
+    get_extraction_regexes,
+)
+from lighteval.metrics.utils.metric_utils import (
+    MetricCategory,
+    MetricUseCase,
+    SampleLevelMetric,
+)
+import numpy as np
 
 
 # IFEVal-fr task
@@ -67,6 +91,65 @@ gpqa_fr_task = LightevalTaskConfig(
     generation_size=1,
     metric=[Metrics.loglikelihood_acc],
     stop_sequence=["\n"],
+    trust_dataset=True,
+    version=0,
+)
+
+
+# Math-Hard-fr task
+math_pass_fr_at_1_1n = SampleLevelMetric(
+    metric_name="math_pass_fr@1:1_samples",
+    sample_level_fn=PassAtK(
+        k=1,
+        n=1,
+        strip_strings=True,
+        # Extracting mathematical expressions and latex expressions
+        normalize_gold=lambda k: extract_target_from_pred(
+            k,
+            get_extraction_regexes(
+                formatted_doc=None,
+                target_types=[
+                    ExprExtractionConfig(),
+                    LatexExtractionConfig(boxed_match_priority=0),
+                ],
+                language=Language.FRENCH,
+            ),
+        ),
+        # Extracting mathematical expressions and latex expressions
+        normalize_pred=lambda k: extract_target_from_pred(
+            k,
+            get_extraction_regexes(
+                formatted_doc=None,
+                target_types=[
+                    ExprExtractionConfig(),
+                    LatexExtractionConfig(boxed_match_priority=0),
+                ],
+                language=Language.FRENCH,
+            ),
+        ),
+        # Uses sympy for comparison
+        sample_scoring_function=compare_gold_target,
+    ).compute,
+    category=MetricCategory.GENERATIVE_SAMPLING,
+    use_case=MetricUseCase.REASONING,
+    corpus_level_fn=np.mean,
+    higher_is_better=True,
+)
+
+math_hard_fr_task = LightevalTaskConfig(
+    name="math-hard-fr",
+    suite=["community"],
+    prompt_function=prompt.prompt_math_hard_fr,
+    hf_repo="le-leadboard/MATH_LVL5_fr",
+    hf_subset="default",
+    hf_avail_splits=["test"],
+    evaluation_splits=["test"],
+    few_shots_split="train",
+    few_shots_select="random",
+    generation_size=4096,
+    metric=[
+        math_pass_fr_at_1_1n,
+    ],
     trust_dataset=True,
     version=0,
 )
@@ -671,6 +754,7 @@ bbh_word_sorting_community = LightevalTaskConfig(
 TASKS_TABLE = [
     ifeval_fr_task,
     gpqa_fr_task,
+    math_hard_fr_task,
     bbh_boolean_expressions_community,
     bbh_causal_judgment_community,
     bbh_date_understanding_community,

--- a/src/eval/tasks.py
+++ b/src/eval/tasks.py
@@ -92,6 +92,29 @@ math_hard_fr_task = LightevalTaskConfig(
     version=0,
 )
 
+# BoolQ-fr task
+boolq_fr_task = LightevalTaskConfig(
+    name="boolq-fr",
+    suite=["community"],
+    prompt_function=custom_prompt.prompt_boolq_fr,
+    hf_repo="manu/french_boolq",
+    hf_subset="default",
+    hf_avail_splits=["train", "valid"],
+    evaluation_splits=["test"],
+    few_shots_split="train",
+    few_shots_select="random",
+    generation_size=5,
+    metrics=[
+        Metrics.exact_match,
+        Metrics.quasi_exact_match,
+        Metrics.prefix_exact_match,
+        Metrics.prefix_quasi_exact_match,
+    ],
+    stop_sequence=["\n"],
+    trust_dataset=True,
+    version=0,
+)
+
 # BBH-fr task
 bbh_boolean_expressions_community = LightevalTaskConfig(
     name="bbh-fr:expressions_booléennes",
@@ -693,6 +716,7 @@ TASKS_TABLE = [
     ifeval_fr_task,
     gpqa_fr_task,
     math_hard_fr_task,
+    boolq_fr_task,
     bbh_boolean_expressions_community,
     bbh_causal_judgment_community,
     bbh_date_understanding_community,

--- a/src/eval/tasks.py
+++ b/src/eval/tasks.py
@@ -71,7 +71,7 @@ gpqa_fr_task = LightevalTaskConfig(
     version=0,
 )
 
-# BigBench Hard task
+# BBH-fr task
 bbh_boolean_expressions_community = LightevalTaskConfig(
     name="bbh-fr:expressions_booléennes",
     suite=["community"],

--- a/src/eval/tasks.py
+++ b/src/eval/tasks.py
@@ -33,20 +33,22 @@ ifeval_fr_task = LightevalTaskConfig(
     version="0.1",
 )
 
-# GPQA-fr task
-gpqa_fr_task = LightevalTaskConfig(
-    name="gpqa-fr",
+# GPQA-Diamond-fr task
+gpqa_diamond_fr_task = LightevalTaskConfig(
+    name="gpqa-diamond-fr",
     suite=["community"],
-    prompt_function=custom_prompt.prompt_gpqa_fr,
+    prompt_function=custom_prompt.gpqa_diamond_fr_instruct,
     hf_repo="le-leadboard/gpqa-fr",
-    hf_subset="default",
+    hf_subset="gpqa_diamond",
     hf_avail_splits=["train"],
     evaluation_splits=["train"],
     few_shots_split="train",
     few_shots_select="random_sampling",
-    generation_size=1,
-    metric=[Metrics.loglikelihood_acc],
-    stop_sequence=["\n"],
+    generation_size=32768,
+    metric=[
+        custom_metric.gpqa_instruct_pass_fr_at_1_1n,
+    ],
+    stop_sequence=[],
     trust_dataset=True,
     version=0,
 )
@@ -774,7 +776,7 @@ bbh_word_sorting_community = LightevalTaskConfig(
 # STORE YOUR EVALS
 TASKS_TABLE = [
     ifeval_fr_task,
-    gpqa_fr_task,
+    gpqa_diamond_fr_task,
     math_hard_fr_task,
     boolq_fr_task,
     mmlu_fr_task,

--- a/src/eval/tasks.py
+++ b/src/eval/tasks.py
@@ -50,7 +50,7 @@ gpqa_diamond_fr_task = LightevalTaskConfig(
     ],
     stop_sequence=[],
     trust_dataset=True,
-    version=0,
+    version=1,
 )
 
 


### PR DESCRIPTION
Adding the ability to run evaluation with a selected model and benchmark using LightEval and vLLM. The main supported benchmarks will likely include:

- [IFEval-fr](https://huggingface.co/datasets/jzhang86/fr_ifeval)
- [GPQA-Diamond-fr](https://huggingface.co/datasets/le-leadboard/gpqa-fr)
- [MMMLU-fr](https://huggingface.co/datasets/openai/MMMLU)
- [MATH_LVL5-fr](https://huggingface.co/datasets/le-leadboard/MATH_LVL5_fr)
- [BBH-fr](https://huggingface.co/datasets/le-leadboard/bbh-fr)
- [BoolQ-fr](https://huggingface.co/datasets/manu/french_boolq)
- [MuSR-fr](https://huggingface.co/datasets/le-leadboard/musr-fr)
